### PR TITLE
Fix --version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/libops/sitectl-isle/cmd"
 	"github.com/libops/sitectl/pkg/plugin"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func main() {
 	sdk := plugin.NewSDK(plugin.Metadata{
 		Name:        "isle",
-		Version:     "v0.0.7",
+		Version:     fmt.Sprintf("%s (Built on %s from Git SHA %s)", version, date, commit),
 		Description: "Islandora (ISLE) utilities and migration tools",
 		Author:      "libops",
 	})


### PR DESCRIPTION
Stop with the hard coded versioning and have this plugin's version leverage cobra's helpers for this like sitectl does

```
$ sitectl --version
sitectl version 0.6.0 (Built on 2026-03-14T13:01:42Z from Git SHA f52e47a5b254d826e3cf278da6e0262ebdada0d4)
$ sitectl isle --version
sitectl isle version v0.0.7
```