### PR TITLE
fix(cache): make mirador warming cancellable and log ready state

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -17,6 +17,13 @@ type URLItem struct {
 	URL string `json:"url"`
 }
 
+type miradorStateSummary struct {
+	ViewerID      string `json:"viewerId"`
+	ManifestCount int    `json:"manifestCount"`
+	WindowCount   int    `json:"windowCount"`
+	ReadyWindows  int    `json:"readyWindows"`
+}
+
 var (
 	endpoint string
 	workers  int
@@ -43,59 +50,42 @@ var cacheMirador = &cobra.Command{
 	Long: `Pre-warm the Mirador IIIF viewer cache for paged content items.
 
 When the IIIF server has not yet cached a paged item's child images, the first visitor to that
-page experiences slow load times while the server processes the images. This command fetches a
-list of paged content URLs from a JSON endpoint and renders each one in a headless browser so
-the IIIF server caches the images before real visitors arrive.`,
+	page experiences slow load times while the server processes the images. This command fetches a
+	list of paged content URLs from a JSON endpoint and renders each one in a headless browser so
+	the IIIF server caches the images before real visitors arrive.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		urls, err := fetchURLs(endpoint)
+		urls, err := fetchURLs(cmd.Context(), endpoint)
 		if err != nil {
 			return fmt.Errorf("error fetching URLs: %v", err)
 		}
 
-		type job struct {
-			URL string
-		}
+		return runMiradorWarm(cmd.Context(), urls, workers, func(parent context.Context, url string) error {
+			execCtx, cancelExec := chromedp.NewExecAllocator(parent, chromedp.DefaultExecAllocatorOptions[:]...)
+			defer cancelExec()
 
-		jobs := make(chan job)
+			browserCtx, cancelBrowser := chromedp.NewContext(execCtx)
+			defer cancelBrowser()
 
-		var wg sync.WaitGroup
-
-		for i := 0; i < workers; i++ {
-			wg.Add(1)
-			go func(workerID int) {
-				defer wg.Done()
-
-				for j := range jobs {
-
-					execCtx, cancelExec := chromedp.NewExecAllocator(context.Background(), chromedp.DefaultExecAllocatorOptions[:]...)
-
-					ctx, cancelCtx := chromedp.NewContext(execCtx)
-					err := warmURL(ctx, j.URL)
-					cancelCtx()
-					cancelExec()
-					if err != nil {
-						slog.Error("worker Failed", "url", j.URL, "err", err)
-					}
-				}
-			}(i + 1)
-		}
-
-		for _, u := range urls {
-			jobs <- job{URL: u}
-		}
-		close(jobs)
-
-		wg.Wait()
-		return nil
+			return warmURL(browserCtx, url)
+		})
 	},
 }
 
-func fetchURLs(endpoint string) ([]string, error) {
-	resp, err := http.Get(endpoint)
+func fetchURLs(ctx context.Context, endpoint string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request failed: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GET failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("GET failed: unexpected status %s", resp.Status)
+	}
 
 	var items []URLItem
 	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
@@ -111,29 +101,110 @@ func fetchURLs(endpoint string) ([]string, error) {
 	return urls, nil
 }
 
+func runMiradorWarm(ctx context.Context, urls []string, workerCount int, warm func(context.Context, string) error) error {
+	if workerCount < 1 {
+		workerCount = 1
+	}
+
+	jobs := make(chan string)
+	var wg sync.WaitGroup
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case url, ok := <-jobs:
+					if !ok {
+						return
+					}
+					if err := warm(ctx, url); err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						slog.Error("worker Failed", "url", url, "err", err)
+					}
+				}
+			}
+		}()
+	}
+
+	defer func() {
+		close(jobs)
+		wg.Wait()
+	}()
+
+	for _, url := range urls {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case jobs <- url:
+		}
+	}
+
+	return nil
+}
+
 func warmURL(ctx context.Context, url string) error {
 	slog.Info("Warming URL", "url", url)
 
 	localCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	var state miradorStateSummary
 	tasks := chromedp.Tasks{
 		chromedp.Navigate(url),
 		chromedp.Poll(`
-			(function($) {
-					const id = $('.block-mirador[data-once*="mirador-viewer"]').attr('id');
-					if (id == undefined) return false;
-					const state = Drupal.IslandoraMirador.instances['#' + id].store.getState();
-					if (!state.manifests || Object.keys(state.manifests).length === 0) return false;
-					if (!state.windows || Object.keys(state.windows).length === 0) return false;
-					const windows = Object.values(state.windows);
-					return windows.some(window => window.canvasId && window.manifestId);
-			})(jQuery);`, nil),
+			(() => {
+				const node = document.querySelector('.block-mirador[data-once*="mirador-viewer"]');
+				if (!node || !node.id) return false;
+				if (!window.Drupal || !Drupal.IslandoraMirador || !Drupal.IslandoraMirador.instances) return false;
+				const instance = Drupal.IslandoraMirador.instances['#' + node.id];
+				if (!instance || !instance.store || typeof instance.store.getState !== 'function') return false;
+				const state = instance.store.getState();
+				if (!state.manifests || Object.keys(state.manifests).length === 0) return false;
+				if (!state.windows || Object.keys(state.windows).length === 0) return false;
+				return Object.values(state.windows).some((win) => win && win.canvasId && win.manifestId);
+			})()`, nil),
+		chromedp.Evaluate(`
+			(() => {
+				const node = document.querySelector('.block-mirador[data-once*="mirador-viewer"]');
+				if (!node || !node.id || !window.Drupal || !Drupal.IslandoraMirador || !Drupal.IslandoraMirador.instances) {
+					return { viewerId: "", manifestCount: 0, windowCount: 0, readyWindows: 0 };
+				}
+				const instance = Drupal.IslandoraMirador.instances['#' + node.id];
+				if (!instance || !instance.store || typeof instance.store.getState !== 'function') {
+					return { viewerId: node.id, manifestCount: 0, windowCount: 0, readyWindows: 0 };
+				}
+				const state = instance.store.getState();
+				const manifests = state.manifests ? Object.keys(state.manifests).length : 0;
+				const windows = state.windows ? Object.values(state.windows) : [];
+				const readyWindows = windows.filter((win) => win && win.canvasId && win.manifestId).length;
+				return {
+					viewerId: node.id,
+					manifestCount: manifests,
+					windowCount: windows.length,
+					readyWindows: readyWindows
+				};
+			})()`, &state),
 	}
 
 	if err := chromedp.Run(localCtx, tasks); err != nil {
 		return err
 	}
+
+	slog.Info(
+		"Mirador ready",
+		"url", url,
+		"viewer_id", state.ViewerID,
+		"manifest_count", state.ManifestCount,
+		"window_count", state.WindowCount,
+		"ready_windows", state.ReadyWindows,
+	)
 
 	return nil
 }

--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFetchURLs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"url":"https://example.test/one"},
+			{"url":""},
+			{"url":"https://example.test/two"}
+		]`))
+	}))
+	defer server.Close()
+
+	got, err := fetchURLs(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchURLs() error = %v", err)
+	}
+
+	want := []string{"https://example.test/one", "https://example.test/two"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fetchURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestFetchURLsRejectsBadStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	_, err := fetchURLs(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("fetchURLs() error = nil, want status error")
+	}
+}
+
+func TestRunMiradorWarmStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runMiradorWarm(ctx, []string{"one", "two", "three"}, 1, func(ctx context.Context, url string) error {
+			mu.Lock()
+			seen = append(seen, url)
+			mu.Unlock()
+
+			select {
+			case <-started:
+			default:
+				close(started)
+			}
+
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first warm call")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("runMiradorWarm() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runMiradorWarm to exit after cancel")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(seen, []string{"one"}) {
+		t.Fatalf("warmed URLs = %v, want only first URL before cancellation", seen)
+	}
+}


### PR DESCRIPTION
I was getting some errors with

```
sitectl isle cache mirador \
  --context isle-preserve-prod \
  --endpoint "https://preserve.lehigh.edu/api/v1/mirador?_format=json"
```

The JS I was using was brittle, so replaced jQuery calls with JS.

Also, `Ctrl+C` wasn't killing the main process so fixed that