### PR TITLE
fix(cache): stream paginated mirador warming with cancellation and state logs

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -3,10 +3,14 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/chromedp/chromedp"
@@ -24,8 +28,16 @@ type miradorStateSummary struct {
 	ReadyWindows  int    `json:"readyWindows"`
 }
 
+type miradorRunStats struct {
+	pagesFetched atomic.Int64
+	urlsQueued   atomic.Int64
+	urlsWarmed   atomic.Int64
+	urlsFailed   atomic.Int64
+}
+
 var (
 	endpoint string
+	limit    int
 	workers  int
 )
 
@@ -39,6 +51,7 @@ func init() {
 	cacheCmd.AddCommand(cacheMirador)
 
 	cacheMirador.Flags().StringVar(&endpoint, "endpoint", "", "JSON endpoint returning an array of objects with a url field. Required.")
+	cacheMirador.Flags().IntVar(&limit, "limit", 0, "Maximum number of URLs to warm. Use 0 to paginate through all endpoint pages.")
 	cacheMirador.Flags().IntVar(&workers, "workers", 2, "Number of concurrent browser workers.")
 	must(cacheMirador.MarkFlagRequired("endpoint"))
 }
@@ -54,12 +67,7 @@ When the IIIF server has not yet cached a paged item's child images, the first v
 	list of paged content URLs from a JSON endpoint and renders each one in a headless browser so
 	the IIIF server caches the images before real visitors arrive.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		urls, err := fetchURLs(cmd.Context(), endpoint)
-		if err != nil {
-			return fmt.Errorf("error fetching URLs: %v", err)
-		}
-
-		return runMiradorWarm(cmd.Context(), urls, workers, func(parent context.Context, url string) error {
+		return runMiradorWarmFromEndpoint(cmd.Context(), endpoint, limit, workers, fetchURLPage, func(parent context.Context, url string) error {
 			execCtx, cancelExec := chromedp.NewExecAllocator(parent, chromedp.DefaultExecAllocatorOptions[:]...)
 			defer cancelExec()
 
@@ -71,8 +79,34 @@ When the IIIF server has not yet cached a paged item's child images, the first v
 	},
 }
 
-func fetchURLs(ctx context.Context, endpoint string) ([]string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+func startingPage(endpoint string) (int, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return 0, fmt.Errorf("parse endpoint failed: %w", err)
+	}
+
+	pageValue := parsed.Query().Get("page")
+	if pageValue == "" {
+		return 0, nil
+	}
+
+	page, err := strconv.Atoi(pageValue)
+	if err != nil {
+		return 0, fmt.Errorf("parse page failed: %w", err)
+	}
+
+	return page, nil
+}
+
+func fetchURLPage(ctx context.Context, endpoint string, page int) ([]URLItem, error) {
+	pageURL, err := endpointPageURL(endpoint, page)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("Fetching Mirador endpoint page", "page", page, "endpoint", pageURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request failed: %w", err)
 	}
@@ -92,21 +126,171 @@ func fetchURLs(ctx context.Context, endpoint string) ([]string, error) {
 		return nil, fmt.Errorf("decode failed: %w", err)
 	}
 
+	return items, nil
+}
+
+func endpointPageURL(endpoint string, page int) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse endpoint failed: %w", err)
+	}
+
+	query := parsed.Query()
+	query.Set("page", strconv.Itoa(page))
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String(), nil
+}
+
+func runMiradorWarmFromEndpoint(
+	ctx context.Context,
+	endpoint string,
+	limit int,
+	workerCount int,
+	fetchPage func(context.Context, string, int) ([]URLItem, error),
+	warm func(context.Context, string) error,
+) error {
+	startedAt := time.Now()
+	stats := &miradorRunStats{}
+	var resultErr error
+	defer func() {
+		slog.Info(
+			"Mirador warm summary",
+			"endpoint", endpoint,
+			"pages_fetched", stats.pagesFetched.Load(),
+			"urls_queued", stats.urlsQueued.Load(),
+			"urls_warmed", stats.urlsWarmed.Load(),
+			"urls_failed", stats.urlsFailed.Load(),
+			"elapsed", time.Since(startedAt).Round(time.Millisecond).String(),
+			"canceled", errors.Is(resultErr, context.Canceled),
+		)
+	}()
+
+	jobs := make(chan string, max(1, workerCount))
+	producerErr := make(chan error, 1)
+
+	go func() {
+		defer close(jobs)
+		producerErr <- enqueueMiradorURLs(ctx, jobs, endpoint, limit, func(ctx context.Context, endpoint string, page int) ([]URLItem, error) {
+			items, err := fetchPage(ctx, endpoint, page)
+			if err == nil {
+				stats.pagesFetched.Add(1)
+			}
+			return items, err
+		}, func(item URLItem) {
+			if item.URL != "" {
+				stats.urlsQueued.Add(1)
+			}
+		})
+	}()
+
+	workerErr := runMiradorWorkers(ctx, jobs, workerCount, func(ctx context.Context, url string) error {
+		err := warm(ctx, url)
+		if err != nil {
+			if ctx.Err() == nil {
+				stats.urlsFailed.Add(1)
+			}
+			return err
+		}
+
+		stats.urlsWarmed.Add(1)
+		return nil
+	})
+	fetchErr := <-producerErr
+
+	if fetchErr != nil && !errors.Is(fetchErr, context.Canceled) {
+		resultErr = fetchErr
+		return resultErr
+	}
+
+	resultErr = workerErr
+	return resultErr
+}
+
+func fetchURLs(ctx context.Context, endpoint string, limit int) ([]string, error) {
 	var urls []string
-	for _, item := range items {
+	err := enqueueMiradorURLs(ctx, nil, endpoint, limit, func(ctx context.Context, endpoint string, page int) ([]URLItem, error) {
+		return fetchURLPage(ctx, endpoint, page)
+	}, func(item URLItem) {
 		if item.URL != "" {
 			urls = append(urls, item.URL)
 		}
+	})
+	if err != nil {
+		return nil, err
 	}
 	return urls, nil
 }
 
+func enqueueMiradorURLs(
+	ctx context.Context,
+	jobs chan<- string,
+	endpoint string,
+	limit int,
+	fetchPage func(context.Context, string, int) ([]URLItem, error),
+	collect ...func(URLItem),
+) error {
+	nextPage, err := startingPage(endpoint)
+	if err != nil {
+		return err
+	}
+
+	sent := 0
+	for {
+		items, err := fetchPage(ctx, endpoint, nextPage)
+		if err != nil {
+			return err
+		}
+		if len(items) == 0 {
+			return nil
+		}
+
+		for _, item := range items {
+			if item.URL == "" {
+				continue
+			}
+			if jobs != nil {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case jobs <- item.URL:
+				}
+			}
+			for _, fn := range collect {
+				fn(item)
+			}
+			sent++
+			if limit > 0 && sent >= limit {
+				return nil
+			}
+		}
+
+		nextPage++
+	}
+}
+
 func runMiradorWarm(ctx context.Context, urls []string, workerCount int, warm func(context.Context, string) error) error {
+	jobs := make(chan string, max(1, workerCount))
+
+	go func() {
+		defer close(jobs)
+		for _, url := range urls {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- url:
+			}
+		}
+	}()
+
+	return runMiradorWorkers(ctx, jobs, workerCount, warm)
+}
+
+func runMiradorWorkers(ctx context.Context, jobs <-chan string, workerCount int, warm func(context.Context, string) error) error {
 	if workerCount < 1 {
 		workerCount = 1
 	}
 
-	jobs := make(chan string)
 	var wg sync.WaitGroup
 
 	for i := 0; i < workerCount; i++ {
@@ -133,20 +317,8 @@ func runMiradorWarm(ctx context.Context, urls []string, workerCount int, warm fu
 		}()
 	}
 
-	defer func() {
-		close(jobs)
-		wg.Wait()
-	}()
-
-	for _, url := range urls {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case jobs <- url:
-		}
-	}
-
-	return nil
+	wg.Wait()
+	return ctx.Err()
 }
 
 func warmURL(ctx context.Context, url string) error {

--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -3,26 +3,36 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 )
 
 func TestFetchURLs(t *testing.T) {
+	responses := map[int]string{
+		0: `[
+			{"url":"https://example.test/one"},
+			{"url":""}
+		]`,
+		1: `[
+			{"url":"https://example.test/two"}
+		]`,
+		2: `[]`,
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[
-			{"url":"https://example.test/one"},
-			{"url":""},
-			{"url":"https://example.test/two"}
-		]`))
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		_, _ = w.Write([]byte(responses[page]))
 	}))
 	defer server.Close()
 
-	got, err := fetchURLs(context.Background(), server.URL)
+	got, err := fetchURLs(context.Background(), server.URL, 0)
 	if err != nil {
 		t.Fatalf("fetchURLs() error = %v", err)
 	}
@@ -39,9 +49,72 @@ func TestFetchURLsRejectsBadStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := fetchURLs(context.Background(), server.URL)
+	_, err := fetchURLs(context.Background(), server.URL, 0)
 	if err == nil {
 		t.Fatal("fetchURLs() error = nil, want status error")
+	}
+}
+
+func TestFetchURLsRespectsLimitAcrossPages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		switch page {
+		case 0:
+			_, _ = w.Write([]byte(`[
+				{"url":"https://example.test/one"},
+				{"url":"https://example.test/two"}
+			]`))
+		case 1:
+			_, _ = w.Write([]byte(`[
+				{"url":"https://example.test/three"}
+			]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer server.Close()
+
+	got, err := fetchURLs(context.Background(), server.URL, 2)
+	if err != nil {
+		t.Fatalf("fetchURLs() error = %v", err)
+	}
+
+	want := []string{"https://example.test/one", "https://example.test/two"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fetchURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestFetchURLsStartsFromEndpointPageParam(t *testing.T) {
+	var pages []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		pages = append(pages, page)
+		switch page {
+		case 4:
+			_, _ = w.Write([]byte(`[
+				{"url":"https://example.test/four"}
+			]`))
+		case 5:
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected page %d", page)
+		}
+	}))
+	defer server.Close()
+
+	got, err := fetchURLs(context.Background(), server.URL+"?page=4&_format=json", 0)
+	if err != nil {
+		t.Fatalf("fetchURLs() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got, []string{"https://example.test/four"}) {
+		t.Fatalf("fetchURLs() = %v, want one result from page 4", got)
+	}
+	if !slices.Equal(pages, []int{4, 5}) {
+		t.Fatalf("pages fetched = %v, want [4 5]", pages)
 	}
 }
 
@@ -94,5 +167,98 @@ func TestRunMiradorWarmStopsOnCancel(t *testing.T) {
 	defer mu.Unlock()
 	if !reflect.DeepEqual(seen, []string{"one"}) {
 		t.Fatalf("warmed URLs = %v, want only first URL before cancellation", seen)
+	}
+}
+
+func TestRunMiradorWarmFromEndpointFetchesWhileWarming(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		fetches []int
+		warms   []string
+	)
+
+	firstWarmStarted := make(chan struct{})
+	releaseFirstWarm := make(chan struct{})
+	pageOneFetched := make(chan struct{})
+
+	fetchPage := func(ctx context.Context, endpoint string, page int) ([]URLItem, error) {
+		mu.Lock()
+		fetches = append(fetches, page)
+		mu.Unlock()
+
+		if page == 1 {
+			select {
+			case <-pageOneFetched:
+			default:
+				close(pageOneFetched)
+			}
+		}
+
+		switch page {
+		case 0:
+			return []URLItem{{URL: "one"}}, nil
+		case 1:
+			return []URLItem{{URL: "two"}}, nil
+		case 2:
+			return []URLItem{}, nil
+		default:
+			return nil, fmt.Errorf("unexpected page %d", page)
+		}
+	}
+
+	warm := func(ctx context.Context, url string) error {
+		mu.Lock()
+		warms = append(warms, url)
+		mu.Unlock()
+
+		if url == "one" {
+			select {
+			case <-firstWarmStarted:
+			default:
+				close(firstWarmStarted)
+			}
+			<-releaseFirstWarm
+		}
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runMiradorWarmFromEndpoint(ctx, "https://example.test/api?_format=json", 0, 1, fetchPage, warm)
+	}()
+
+	select {
+	case <-firstWarmStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first warm to start")
+	}
+
+	select {
+	case <-pageOneFetched:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second page fetch while first warm was running")
+	}
+
+	close(releaseFirstWarm)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runMiradorWarmFromEndpoint() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runMiradorWarmFromEndpoint to complete")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !slices.Equal(fetches, []int{0, 1, 2}) {
+		t.Fatalf("pages fetched = %v, want [0 1 2]", fetches)
+	}
+	if !reflect.DeepEqual(warms, []string{"one", "two"}) {
+		t.Fatalf("warmed URLs = %v, want [one two]", warms)
 	}
 }


### PR DESCRIPTION
don't require the endpoint to return all item URLs. Instead, paginate over the endpoint