### PR TITLE
Fix ISLE create smoke options

### DIFF
--- a/cmd/component_review.go
+++ b/cmd/component_review.go
@@ -69,7 +69,7 @@ func runComponentReconcile(cmd *cobra.Command, opts componentReconcileOptions) e
 	if ctx.DockerHostType != config.ContextLocal {
 		return fmt.Errorf("component review is local-only; context %q is %q", ctx.Name, ctx.DockerHostType)
 	}
-	rootfs, err := resolveCodebaseRootfsFlag(cmd, opts.CodebaseRootfs, opts.DrupalRootfs)
+	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, opts.CodebaseRootfs, opts.DrupalRootfs)
 	if err != nil {
 		return err
 	}

--- a/cmd/component_set.go
+++ b/cmd/component_set.go
@@ -64,7 +64,7 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 	if ctx.DockerHostType != config.ContextLocal {
 		return fmt.Errorf("component changes are local-only; context %q is %q", ctx.Name, ctx.DockerHostType)
 	}
-	rootfs, err := resolveCodebaseRootfsFlag(cmd, opts.CodebaseRootfs, opts.DrupalRootfs)
+	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, opts.CodebaseRootfs, opts.DrupalRootfs)
 	if err != nil {
 		return err
 	}
@@ -200,11 +200,15 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 	}
 
 	if applyOpts.Fcrepo == createpkg.FcrepoStateOff {
-		scheme, err := resolveCurrentFileSystemURI(ctx.ProjectDir, rootfs)
-		if err != nil {
-			return err
+		if scheme := selectedFcrepoFileSystemURI(cmd, followUps, opts); scheme != "" {
+			applyOpts.ISLEFileSystemURI = scheme
+		} else {
+			scheme, err := resolveCurrentFileSystemURI(ctx.ProjectDir, rootfs)
+			if err != nil {
+				return err
+			}
+			applyOpts.ISLEFileSystemURI = scheme
 		}
-		applyOpts.ISLEFileSystemURI = scheme
 	}
 
 	if err := componentApplyOptions(applyOpts); err != nil {
@@ -660,18 +664,14 @@ func (r *isleSetRunner) BindFlags(cmd *cobra.Command) {
 }
 
 func (r *isleSetRunner) Run(cmd *cobra.Command, args []string, ctx *config.Context) error {
-	rootfs, err := resolveCodebaseRootfsFlag(cmd, r.codebaseRootfs, r.drupalRootfs)
-	if err != nil {
-		return err
-	}
 	stateValue, err := resolveComponentSetStateValueFrom(cmd, args, r.state, r.disposition)
 	if err != nil {
 		return err
 	}
 	return runComponentSetWithOptions(cmd, args[0], stateValue, componentSetOptions{
 		Path:           r.path,
-		CodebaseRootfs: rootfs,
-		DrupalRootfs:   rootfs,
+		CodebaseRootfs: r.codebaseRootfs,
+		DrupalRootfs:   r.drupalRootfs,
 		State:          r.state,
 		Disposition:    r.disposition,
 		Yolo:           r.yolo,
@@ -695,6 +695,20 @@ func resolveCurrentFileSystemURI(projectDir, drupalRootfs string) (string, error
 		}
 	}
 	return createpkg.DefaultISLEFileSystemURI, nil
+}
+
+func selectedFcrepoFileSystemURI(cmd *cobra.Command, followUps map[string]string, opts componentSetOptions) string {
+	scheme := strings.TrimSpace(followUps["isle-file-system-uri"])
+	if scheme == "" {
+		return ""
+	}
+	if !opts.Yolo {
+		return scheme
+	}
+	if cmd == nil || cmd.Flags().Lookup("isle-file-system-uri") == nil || !cmd.Flags().Changed("isle-file-system-uri") {
+		return ""
+	}
+	return scheme
 }
 
 func addComponentSetFollowUpFlags(cmd *cobra.Command, defs []corecomponent.Definition) {

--- a/cmd/component_set_test.go
+++ b/cmd/component_set_test.go
@@ -127,6 +127,49 @@ func TestRunComponentSetUsesCurrentFilesystemURIWhenTurningFcrepoOff(t *testing.
 	}
 }
 
+func TestRunComponentSetUsesExplicitFilesystemURIWhenTurningFcrepoOff(t *testing.T) {
+	projectDir := t.TempDir()
+	writeISLEOnFixture(t, projectDir)
+
+	fieldPath := filepath.Join(projectDir, createpkg.DefaultDrupalRootfs, "config", "sync", "field.storage.media.field_media_file.yml")
+	writeFileForTest(t, fieldPath, "settings:\n  uri_scheme: \"archive\"\n")
+
+	oldStatusPath := statusPath
+	oldDrupalRootfs := statusDrupalRootfs
+	oldYolo := componentSetYolo
+	oldApply := componentApplyOptions
+	oldPromptChoice := componentPromptChoice
+	t.Cleanup(func() {
+		statusPath = oldStatusPath
+		statusDrupalRootfs = oldDrupalRootfs
+		componentSetYolo = oldYolo
+		componentApplyOptions = oldApply
+		componentPromptChoice = oldPromptChoice
+	})
+
+	statusPath = projectDir
+	statusDrupalRootfs = createpkg.DefaultDrupalRootfs
+	componentSetYolo = true
+
+	var got createpkg.Options
+	componentApplyOptions = func(opts createpkg.Options) error {
+		got = opts
+		return nil
+	}
+
+	cmd := newComponentSetTestCommand()
+	if err := cmd.Flags().Set("isle-file-system-uri", "private"); err != nil {
+		t.Fatalf("Flags().Set(isle-file-system-uri) error = %v", err)
+	}
+
+	if err := runComponentSet(cmd, "fcrepo", "off"); err != nil {
+		t.Fatalf("runComponentSet() error = %v", err)
+	}
+	if got.ISLEFileSystemURI != "private" {
+		t.Fatalf("expected explicit private filesystem uri, got %q", got.ISLEFileSystemURI)
+	}
+}
+
 func TestRunComponentSetSwitchesDefaultCodebaseToGitRoot(t *testing.T) {
 	projectDir := t.TempDir()
 	writeISLEOnFixture(t, projectDir)
@@ -246,6 +289,89 @@ func TestRunComponentSetSwitchesDefaultCodebaseToGitRoot(t *testing.T) {
 		}
 	}
 	t.Fatal("expected codebase component status after switch")
+}
+
+func TestRunComponentSetUsesContextRootfsAfterCodebaseGitRoot(t *testing.T) {
+	projectDir := t.TempDir()
+	writeISLEOnFixture(t, projectDir)
+	writeISLEDefaultCodebaseFixture(t, projectDir)
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	if err := config.SaveContext(&config.Context{
+		Name:           "isle-local",
+		Site:           "isle-local",
+		Plugin:         "isle",
+		DockerHostType: config.ContextLocal,
+		DockerSocket:   "/var/run/docker.sock",
+		ProjectDir:     projectDir,
+		DrupalRootfs:   createpkg.DefaultDrupalRootfs,
+	}, true); err != nil {
+		t.Fatalf("SaveContext() error = %v", err)
+	}
+
+	oldSDK := commandSDK
+	oldStatusPath := statusPath
+	oldStatusCodebaseRootfs := statusCodebaseRootfs
+	oldStatusDrupalRootfs := statusDrupalRootfs
+	oldYolo := componentSetYolo
+	oldApply := componentApplyOptions
+	oldPromptChoice := componentPromptChoice
+	t.Cleanup(func() {
+		commandSDK = oldSDK
+		statusPath = oldStatusPath
+		statusCodebaseRootfs = oldStatusCodebaseRootfs
+		statusDrupalRootfs = oldStatusDrupalRootfs
+		componentSetYolo = oldYolo
+		componentApplyOptions = oldApply
+		componentPromptChoice = oldPromptChoice
+	})
+
+	commandSDK = plugin.NewSDK(plugin.Metadata{
+		Name:        "isle",
+		Version:     "test",
+		Description: "test",
+	})
+	commandSDK.Config.Context = "isle-local"
+	statusPath = ""
+	statusCodebaseRootfs = createpkg.DefaultDrupalRootfs
+	statusDrupalRootfs = createpkg.DefaultDrupalRootfs
+	componentSetYolo = true
+	componentApplyOptions = createpkg.Apply
+
+	if err := runComponentSet(newComponentSetTestCommand(), "codebase", "git-root"); err != nil {
+		t.Fatalf("runComponentSet(codebase) error = %v", err)
+	}
+	stored, err := config.GetContext("isle-local")
+	if err != nil {
+		t.Fatalf("GetContext() error = %v", err)
+	}
+	if stored.DrupalRootfs != corecomponent.DefaultDrupalRootfs {
+		t.Fatalf("expected stored rootfs %q, got %q", corecomponent.DefaultDrupalRootfs, stored.DrupalRootfs)
+	}
+
+	fcrepoCmd := newComponentSetTestCommand()
+	if err := fcrepoCmd.Flags().Set("isle-file-system-uri", "private"); err != nil {
+		t.Fatalf("Flags().Set(isle-file-system-uri) error = %v", err)
+	}
+	if err := runComponentSet(fcrepoCmd, "fcrepo", "superceded"); err != nil {
+		t.Fatalf("runComponentSet(fcrepo) error = %v", err)
+	}
+	if err := runComponentSet(newComponentSetTestCommand(), "blazegraph", "disabled"); err != nil {
+		t.Fatalf("runComponentSet(blazegraph) error = %v", err)
+	}
+
+	compose := readFileForTest(t, filepath.Join(projectDir, "docker-compose.yml"))
+	for _, absent := range []string{"\n  fcrepo:\n", "\n  blazegraph:\n", "fcrepo-data", "blazegraph-data"} {
+		if strings.Contains(compose, absent) {
+			t.Fatalf("expected %q removed after component sequence, got:\n%s", absent, compose)
+		}
+	}
+	field := readFileForTest(t, filepath.Join(projectDir, "config", "sync", "field.storage.media.field_media_file.yml"))
+	if !strings.Contains(field, `uri_scheme: "private"`) && !strings.Contains(field, "uri_scheme: private") {
+		t.Fatalf("expected fcrepo replacement to use private files, got:\n%s", field)
+	}
 }
 
 func TestIsleSetRunnerPropagatesCodebaseRootfsAliases(t *testing.T) {

--- a/cmd/component_set_test.go
+++ b/cmd/component_set_test.go
@@ -1310,6 +1310,50 @@ func TestResolveCodebaseRootfsFlagRejectsConflictingAliases(t *testing.T) {
 	}
 }
 
+func TestResolveCodebaseRootfsForContextUsesSavedContextRootfs(t *testing.T) {
+	var codebaseRootfs string
+	var drupalRootfs string
+	cmd := &cobra.Command{Use: "test"}
+	addCodebaseRootfsFlags(cmd, &codebaseRootfs, &drupalRootfs, createpkg.DefaultDrupalRootfs)
+
+	got, err := resolveCodebaseRootfsForContext(cmd, &config.Context{
+		ProjectDir:   t.TempDir(),
+		DrupalRootfs: corecomponent.DefaultDrupalRootfs,
+	}, codebaseRootfs, drupalRootfs)
+	if err != nil {
+		t.Fatalf("resolveCodebaseRootfsForContext() error = %v", err)
+	}
+	if got != corecomponent.DefaultDrupalRootfs {
+		t.Fatalf("expected saved context rootfs %q, got %q", corecomponent.DefaultDrupalRootfs, got)
+	}
+}
+
+func TestResolveCodebaseRootfsForContextDetectsCurrentDrupalLayout(t *testing.T) {
+	projectDir := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(projectDir, "drupal", "config", "sync"),
+		filepath.Join(projectDir, "drupal", "web"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s) error = %v", dir, err)
+		}
+	}
+	writeFileForTest(t, filepath.Join(projectDir, "drupal", "composer.json"), "{}\n")
+
+	var codebaseRootfs string
+	var drupalRootfs string
+	cmd := &cobra.Command{Use: "test"}
+	addCodebaseRootfsFlags(cmd, &codebaseRootfs, &drupalRootfs, createpkg.DefaultDrupalRootfs)
+
+	got, err := resolveCodebaseRootfsForContext(cmd, &config.Context{ProjectDir: projectDir}, codebaseRootfs, drupalRootfs)
+	if err != nil {
+		t.Fatalf("resolveCodebaseRootfsForContext() error = %v", err)
+	}
+	if got != "drupal" {
+		t.Fatalf("expected detected current Drupal layout %q, got %q", "drupal", got)
+	}
+}
+
 func writeFileForTest(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -485,7 +485,8 @@ func bootstrapCheckout(out io.Writer, projectDir string) error {
 	fmt.Fprintln(out)
 
 	return runWithSpinner(out, "Creating initial git commit", func() error {
-		if err := createRunProjectCommand(projectDir, io.Discard, io.Discard, "git", "add", "."); err != nil {
+		safeDirectory := "safe.directory=" + projectDir
+		if err := createRunProjectCommand(projectDir, io.Discard, io.Discard, "git", "-c", safeDirectory, "add", "."); err != nil {
 			return fmt.Errorf("stage initial checkout: %w", err)
 		}
 		if err := createRunProjectCommand(
@@ -493,6 +494,7 @@ func bootstrapCheckout(out io.Writer, projectDir string) error {
 			io.Discard,
 			io.Discard,
 			"git",
+			"-c", safeDirectory,
 			"-c", "user.name=sitectl-isle",
 			"-c", "user.email=sitectl-isle@localhost",
 			"commit",

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -831,10 +831,10 @@ func TestBootstrapCheckoutRunsGitAddAndInitialCommit(t *testing.T) {
 	if len(commands) != 2 {
 		t.Fatalf("expected 2 git commands, got %#v", commands)
 	}
-	if got := strings.Join(commands[0], " "); got != "git add ." {
+	if got, want := strings.Join(commands[0], " "), fmt.Sprintf("git -c safe.directory=%s add .", projectDir); got != want {
 		t.Fatalf("expected first command `git add .`, got %q", got)
 	}
-	if got := strings.Join(commands[1], " "); got != "git -c user.name=sitectl-isle -c user.email=sitectl-isle@localhost commit -m initial commit." {
+	if got, want := strings.Join(commands[1], " "), fmt.Sprintf("git -c safe.directory=%s -c user.name=sitectl-isle -c user.email=sitectl-isle@localhost commit -m initial commit.", projectDir); got != want {
 		t.Fatalf("unexpected commit command %q", got)
 	}
 }

--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -82,7 +82,7 @@ func (r *isleDebugRunner) BindFlags(cmd *cobra.Command) {
 }
 
 func (r *isleDebugRunner) Render(cmd *cobra.Command, ctx *config.Context) (string, error) {
-	rootfs, err := resolveCodebaseRootfsFlag(cmd, r.codebaseRootfs, r.drupalRootfs)
+	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, r.codebaseRootfs, r.drupalRootfs)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/rootfs_flags.go
+++ b/cmd/rootfs_flags.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	corecomponent "github.com/libops/sitectl/pkg/component"
+	"github.com/libops/sitectl/pkg/config"
 	"github.com/spf13/cobra"
 )
 
@@ -35,4 +38,54 @@ func resolveCodebaseRootfsFlag(cmd *cobra.Command, codebaseRootfs, drupalRootfs 
 		return codebaseRootfs, nil
 	}
 	return drupalRootfs, nil
+}
+
+func resolveCodebaseRootfsForContext(cmd *cobra.Command, ctx *config.Context, codebaseRootfs, drupalRootfs string) (string, error) {
+	codebaseChanged := cmd != nil && cmd.Flags().Changed("codebase-rootfs")
+	drupalChanged := cmd != nil && cmd.Flags().Changed("drupal-rootfs")
+	if codebaseChanged || drupalChanged {
+		return resolveCodebaseRootfsFlag(cmd, codebaseRootfs, drupalRootfs)
+	}
+	if ctx != nil {
+		if rootfs := strings.TrimSpace(ctx.DrupalRootfs); rootfs != "" {
+			return rootfs, nil
+		}
+		if rootfs := detectCodebaseRootfs(ctx.ProjectDir, codebaseRootfs, drupalRootfs); rootfs != "" {
+			return rootfs, nil
+		}
+	}
+	return resolveCodebaseRootfsFlag(cmd, codebaseRootfs, drupalRootfs)
+}
+
+func detectCodebaseRootfs(projectDir string, candidates ...string) string {
+	projectDir = strings.TrimSpace(projectDir)
+	if projectDir == "" {
+		return ""
+	}
+	seen := map[string]bool{}
+	for _, candidate := range append(candidates, "drupal/rootfs/var/www/drupal", "drupal", corecomponent.DefaultDrupalRootfs) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		if codebaseRootfsExists(projectDir, candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func codebaseRootfsExists(projectDir, rootfs string) bool {
+	layout := corecomponent.ResolveDrupalLayout(projectDir, rootfs)
+	for _, path := range []string{
+		layout.ConfigSyncDir(),
+		layout.ComposerJSONPath(),
+		filepath.Join(layout.Root, "web", "robots.txt"),
+	} {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,6 +11,7 @@ import (
 	corecomponent "github.com/libops/sitectl/pkg/component"
 	"github.com/libops/sitectl/pkg/config"
 	"github.com/libops/sitectl/pkg/plugin"
+	coretraefik "github.com/libops/sitectl/pkg/services/traefik"
 	"github.com/spf13/cobra"
 )
 
@@ -118,11 +119,13 @@ func detectComponentViewsForContext(siteCtx *config.Context, drupalRootfs string
 
 	views := make([]componentView, 0, len(sdkStatuses)+2)
 	for i := range sdkStatuses {
+		state := sdkStatuses[i].State
+		sdkStatus := &sdkStatuses[i]
 		followUps := map[string]string{}
-		disposition := dispositionFromDetectedState(sdkStatuses[i].State)
+		disposition := dispositionFromDetectedState(state)
 		switch sdkStatuses[i].Name {
 		case "fcrepo":
-			if sdkStatuses[i].State != corecomponent.DetectedState(corecomponent.StateOff) {
+			if state != corecomponent.DetectedState(corecomponent.StateOff) {
 				break
 			}
 			disposition = corecomponent.DispositionSuperseded
@@ -141,18 +144,27 @@ func detectComponentViewsForContext(siteCtx *config.Context, drupalRootfs string
 				followUps["upstream-url"] = strings.TrimSpace(upstream)
 			}
 		case "codebase":
-			disposition = codebaseDisposition(sdkStatuses[i].State)
+			disposition = codebaseDisposition(state)
+		case coretraefik.BotMitigationName:
+			if enabled, known := localBotMitigationConfigured(siteCtx.ProjectDir); known {
+				state = corecomponent.DetectedState(corecomponent.StateOff)
+				if enabled {
+					state = corecomponent.DetectedState(corecomponent.StateOn)
+				}
+				disposition = dispositionFromDetectedState(state)
+				sdkStatus = nil
+			}
 		default:
 			if createpkg.IsDerivativeService(sdkStatuses[i].Name) {
-				disposition = derivativeServiceDisposition(sdkStatuses[i].State)
+				disposition = derivativeServiceDisposition(state)
 			}
 		}
 		views = append(views, componentView{
 			Definition:     definitions[sdkStatuses[i].Name],
 			Name:           sdkStatuses[i].Name,
-			State:          sdkStatuses[i].State,
+			State:          state,
 			Disposition:    disposition,
-			SDKStatus:      &sdkStatuses[i],
+			SDKStatus:      sdkStatus,
 			FollowUpValues: followUps,
 		})
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -50,7 +50,7 @@ func runComponentDescribe(cmd *cobra.Command, opts componentDescribeOptions) err
 	if err != nil {
 		return err
 	}
-	rootfs, err := resolveCodebaseRootfsFlag(cmd, opts.CodebaseRootfs, opts.DrupalRootfs)
+	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, opts.CodebaseRootfs, opts.DrupalRootfs)
 	if err != nil {
 		return err
 	}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -11,6 +11,7 @@ import (
 	corecomponent "github.com/libops/sitectl/pkg/component"
 	"github.com/libops/sitectl/pkg/config"
 	"github.com/libops/sitectl/pkg/plugin"
+	sitevalidate "github.com/libops/sitectl/pkg/validate"
 	"github.com/spf13/cobra"
 )
 
@@ -432,6 +433,43 @@ services:
 	}
 	if !strings.Contains(rendered, "TLS mode: http") {
 		t.Fatalf("expected dev tls follow-up, got:\n%s", rendered)
+	}
+}
+
+func TestRunIsleValidationAcceptsTripletIIIFConfig(t *testing.T) {
+	projectDir := t.TempDir()
+	writeISLEOnFixture(t, projectDir)
+
+	if err := createpkg.ApplyIIIF(createpkg.Options{
+		Path:         projectDir,
+		DrupalRootfs: createpkg.DefaultDrupalRootfs,
+		IIIF:         createpkg.IIIFTriplet,
+	}); err != nil {
+		t.Fatalf("ApplyIIIF() error = %v", err)
+	}
+
+	results, err := runIsleValidation(&config.Context{
+		Name:           "isle-local",
+		Site:           "isle-local",
+		Plugin:         "isle",
+		DockerHostType: config.ContextLocal,
+		ProjectDir:     projectDir,
+	}, createpkg.DefaultDrupalRootfs)
+	if err != nil {
+		t.Fatalf("runIsleValidation() error = %v", err)
+	}
+
+	byName := map[string]sitevalidate.Result{}
+	for _, result := range results {
+		byName[result.Name] = result
+	}
+	for _, name := range []string{"component:iiif", "component:bot-mitigation", "traefik-triplet-config", "triplet-config"} {
+		if byName[name].Status != sitevalidate.StatusOK {
+			t.Fatalf("expected %s ok, got %+v", name, byName[name])
+		}
+	}
+	if result, ok := byName["traefik-cantaloupe-config"]; ok && result.Status == sitevalidate.StatusFailed {
+		t.Fatalf("did not expect Cantaloupe config failure for Triplet, got %+v", result)
 	}
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -24,7 +24,7 @@ func (r *isleValidateRunner) BindFlags(cmd *cobra.Command) {
 }
 
 func (r *isleValidateRunner) Run(cmd *cobra.Command, ctx *config.Context) ([]sitevalidate.Result, error) {
-	rootfs, err := resolveCodebaseRootfsFlag(cmd, r.codebaseRootfs, r.drupalRootfs)
+	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, r.codebaseRootfs, r.drupalRootfs)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,9 @@ func runIsleValidation(ctx *config.Context, drupalRootfs string) ([]sitevalidate
 	if err != nil {
 		return nil, err
 	}
+	statusByName := map[string]componentView{}
 	for _, status := range statuses {
+		statusByName[status.Name] = status
 		result := sitevalidate.Result{
 			Name:   "component:" + status.Name,
 			Status: sitevalidate.StatusOK,
@@ -95,27 +97,39 @@ func runIsleValidation(ctx *config.Context, drupalRootfs string) ([]sitevalidate
 		results = append(results, result)
 	}
 
-	traefikPath := filepath.Join(ctx.ProjectDir, "conf", "traefik", "cantaloupe.yml")
-	if exists, err := ctx.FileExists(traefikPath); err != nil {
-		results = append(results, sitevalidate.Result{
-			Name:   "traefik-cantaloupe-config",
-			Status: sitevalidate.StatusFailed,
-			Detail: err.Error(),
-		})
-	} else if !exists {
-		results = append(results, sitevalidate.Result{
-			Name:    "traefik-cantaloupe-config",
-			Status:  sitevalidate.StatusFailed,
-			Detail:  fmt.Sprintf("%s not found", traefikPath),
-			FixHint: "ensure this is an ISLE checkout with the expected Traefik config",
-		})
+	if statusByName["iiif"].Disposition == corecomponent.DispositionTriplet {
+		results = append(results,
+			validateProjectFile(ctx, "traefik-triplet-config", filepath.Join("conf", "traefik", "triplet.yml")),
+			validateProjectFile(ctx, "triplet-config", filepath.Join("conf", "triplet", "config.yaml")),
+		)
 	} else {
-		results = append(results, sitevalidate.Result{
-			Name:   "traefik-cantaloupe-config",
-			Status: sitevalidate.StatusOK,
-			Detail: traefikPath,
-		})
+		results = append(results,
+			validateProjectFile(ctx, "traefik-cantaloupe-config", filepath.Join("conf", "traefik", "cantaloupe.yml")),
+		)
 	}
 
 	return results, nil
+}
+
+func validateProjectFile(ctx *config.Context, name, relPath string) sitevalidate.Result {
+	path := filepath.Join(ctx.ProjectDir, relPath)
+	if exists, err := ctx.FileExists(path); err != nil {
+		return sitevalidate.Result{
+			Name:   name,
+			Status: sitevalidate.StatusFailed,
+			Detail: err.Error(),
+		}
+	} else if !exists {
+		return sitevalidate.Result{
+			Name:    name,
+			Status:  sitevalidate.StatusFailed,
+			Detail:  fmt.Sprintf("%s not found", path),
+			FixHint: "ensure this is an ISLE checkout with the expected config",
+		}
+	}
+	return sitevalidate.Result{
+		Name:   name,
+		Status: sitevalidate.StatusOK,
+		Detail: path,
+	}
 }

--- a/pkg/create/apply.go
+++ b/pkg/create/apply.go
@@ -90,6 +90,7 @@ func Apply(opts Options) error {
 	if opts.DrupalRootfs == "" {
 		opts.DrupalRootfs = DefaultDrupalRootfs
 	}
+	opts.DrupalRootfs = resolveProjectDrupalRootfs(opts.Path, opts.DrupalRootfs)
 	if opts.Fcrepo == "" {
 		opts.Fcrepo = FcrepoStateOn
 	}
@@ -183,6 +184,42 @@ func Apply(opts Options) error {
 	}
 
 	return nil
+}
+
+func resolveProjectDrupalRootfs(projectDir, drupalRootfs string) string {
+	root := strings.TrimSpace(drupalRootfs)
+	if root == "" {
+		root = DefaultDrupalRootfs
+	}
+	if filepath.IsAbs(root) || root != DefaultDrupalRootfs {
+		return root
+	}
+	if drupalLayoutExists(projectDir, root) {
+		return root
+	}
+	for _, candidate := range []string{"drupal", corecomponent.DefaultDrupalRootfs} {
+		if candidate == root {
+			continue
+		}
+		if drupalLayoutExists(projectDir, candidate) {
+			return candidate
+		}
+	}
+	return root
+}
+
+func drupalLayoutExists(projectDir, drupalRootfs string) bool {
+	layout := corecomponent.ResolveDrupalLayout(projectDir, drupalRootfs)
+	for _, path := range []string{
+		layout.ConfigSyncDir(),
+		layout.ComposerJSONPath(),
+		filepath.Join(layout.Root, "web", "robots.txt"),
+	} {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func isleBotMitigationOptions() coretraefik.BotMitigationOptions {

--- a/pkg/create/apply.go
+++ b/pkg/create/apply.go
@@ -237,6 +237,9 @@ func applyCodebaseGitRoot(projectDir string) error {
 	if err := moveIfExists(filepath.Join(projectDir, "drupal", ".dockerignore"), filepath.Join(projectDir, ".dockerignore")); err != nil {
 		return err
 	}
+	if err := moveDrupalCodebaseContents(filepath.Join(projectDir, "drupal"), projectDir); err != nil {
+		return err
+	}
 	if err := moveDirectoryContents(filepath.Join(projectDir, "drupal", "rootfs", "var", "www", "drupal"), projectDir, false); err != nil {
 		return err
 	}
@@ -251,6 +254,28 @@ func applyCodebaseGitRoot(projectDir string) error {
 	}
 	if err := rewriteCodebaseDevComposePaths(filepath.Join(projectDir, "docker-compose.dev.yml")); err != nil {
 		return err
+	}
+	return nil
+}
+
+func moveDrupalCodebaseContents(sourceDir, targetDir string) error {
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", sourceDir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || name == "Dockerfile" || name == "README.md" || name == "rootfs" {
+			continue
+		}
+		source := filepath.Join(sourceDir, name)
+		target := filepath.Join(targetDir, name)
+		if err := os.Rename(source, target); err != nil {
+			return fmt.Errorf("move %s to %s: %w", source, target, err)
+		}
 	}
 	return nil
 }

--- a/pkg/create/apply_test.go
+++ b/pkg/create/apply_test.go
@@ -487,6 +487,98 @@ RUN --mount=type=cache,id=custom-drupal-composer-${TARGETARCH},sharing=locked,ta
 	}
 }
 
+func TestApplyCodebaseGitRootFromCurrentDrupalLayout(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	drupalRoot := filepath.Join(projectDir, "drupal")
+	for _, dir := range []string{
+		filepath.Join(drupalRoot, "assets"),
+		filepath.Join(drupalRoot, "config", "sync"),
+		filepath.Join(drupalRoot, "web", "modules", "custom"),
+		filepath.Join(drupalRoot, "web", "themes", "custom"),
+		filepath.Join(drupalRoot, "rootfs", "etc", "s6-overlay", "scripts"),
+		filepath.Join(drupalRoot, "rootfs", "opt", "solr"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s) error = %v", dir, err)
+		}
+	}
+
+	writeTestFile(t, filepath.Join(projectDir, "README.md"), "project readme\n")
+	writeTestFile(t, filepath.Join(drupalRoot, "README.md"), "drupal readme\n")
+	writeTestFile(t, filepath.Join(drupalRoot, "Dockerfile"), `# syntax=docker/dockerfile:1.23.0
+ARG BASE_IMAGE=libops/islandora:php84
+FROM ${BASE_IMAGE}
+
+ARG TARGETARCH
+
+COPY --link composer.json composer.lock /var/www/drupal/
+COPY --link assets/ /var/www/drupal/assets/
+COPY --link rootfs/opt/ /opt/
+`)
+	writeTestFile(t, filepath.Join(drupalRoot, ".dockerignore"), "README.md\n")
+	writeTestFile(t, filepath.Join(projectDir, "docker-compose.yml"), `services:
+  init:
+    volumes:
+      - ./drupal:/drupal:rw
+  drupal:
+    build:
+      context: ./drupal
+`)
+	for _, rel := range []string{
+		"assets/default_settings.txt",
+		"composer.json",
+		"composer.lock",
+		"config/sync/system.site.yml",
+		"web/modules/custom/.gitkeep",
+		"web/themes/custom/.gitkeep",
+	} {
+		writeTestFile(t, filepath.Join(drupalRoot, rel), rel+"\n")
+	}
+
+	if err := applyCodebaseGitRoot(projectDir); err != nil {
+		t.Fatalf("applyCodebaseGitRoot() error = %v", err)
+	}
+
+	for _, rel := range []string{"Dockerfile", ".dockerignore", "composer.json", "composer.lock", "assets/default_settings.txt", "config/sync/system.site.yml", "web/modules/custom/.gitkeep"} {
+		if _, err := os.Stat(filepath.Join(projectDir, rel)); err != nil {
+			t.Fatalf("expected %s at git root: %v", rel, err)
+		}
+		if _, err := os.Stat(filepath.Join(drupalRoot, rel)); !os.IsNotExist(err) {
+			t.Fatalf("expected drupal/%s moved to git root, stat err = %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(drupalRoot, "rootfs", "etc", "s6-overlay", "scripts")); err != nil {
+		t.Fatalf("expected drupal/rootfs overlays preserved: %v", err)
+	}
+	if got := readTestFile(t, filepath.Join(projectDir, "README.md")); got != "project readme\n" {
+		t.Fatalf("expected project README preserved, got %q", got)
+	}
+	if got := readTestFile(t, filepath.Join(drupalRoot, "README.md")); got != "drupal readme\n" {
+		t.Fatalf("expected drupal README left in place, got %q", got)
+	}
+
+	dockerfile := readTestFile(t, filepath.Join(projectDir, "Dockerfile"))
+	for _, want := range []string{
+		"COPY --link composer.json composer.lock /var/www/drupal/",
+		"COPY --link drupal/rootfs/etc/ /etc/",
+		"COPY --link drupal/rootfs/opt/ /opt/",
+	} {
+		if !strings.Contains(dockerfile, want) {
+			t.Fatalf("expected Dockerfile to contain %q, got:\n%s", want, dockerfile)
+		}
+	}
+
+	compose := readTestFile(t, filepath.Join(projectDir, "docker-compose.yml"))
+	if !strings.Contains(compose, "context: .") || strings.Contains(compose, "context: ./drupal") {
+		t.Fatalf("expected drupal build context to be git root, got:\n%s", compose)
+	}
+	if !strings.Contains(compose, "- .:/drupal:rw") || strings.Contains(compose, "- ./drupal:/drupal:rw") {
+		t.Fatalf("expected init volume to mount git root, got:\n%s", compose)
+	}
+}
+
 func TestApplyCreateMatrix(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/create/apply_test.go
+++ b/pkg/create/apply_test.go
@@ -127,6 +127,102 @@ volumes:
 	}
 }
 
+func TestApplyFcrepoOffTripletDetectsCurrentDrupalLayout(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	configDir := filepath.Join(projectDir, "drupal", "config", "sync")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(config) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "drupal", "web"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(web) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "docker-compose.yml"), []byte(`
+services:
+  alpaca:
+    environment:
+      ALPACA_FCREPO_INDEXER_ENABLED: "true"
+      ALPACA_TRIPLESTORE_INDEXER_ENABLED: "true"
+  blazegraph:
+    image: islandora/blazegraph
+  cantaloupe:
+    image: islandora/cantaloupe
+  drupal:
+    environment:
+      DRUPAL_DEFAULT_CANTALOUPE_URL: ${URI_SCHEME}://${DOMAIN}/cantaloupe/iiif/2
+      DRUPAL_DEFAULT_FCREPO_HOST: fcrepo
+      DRUPAL_DEFAULT_FCREPO_PORT: 8080
+      DRUPAL_DEFAULT_FCREPO_URL: ${URI_SCHEME}://fcrepo.${DOMAIN}/fcrepo/rest/
+      DRUPAL_DEFAULT_TRIPLESTORE_NAMESPACE: islandora
+  fcrepo:
+    image: islandora/fcrepo6
+  traefik:
+    environment: {}
+  triplet:
+    image: ghcr.io/libops/triplet:v1.1.0
+    depends_on:
+      fcrepo:
+        condition: service_healthy
+    volumes:
+      - type: volume
+        source: fcrepo-data
+        target: /fcrepo
+volumes:
+  blazegraph-data: {}
+  cantaloupe-data: {}
+  fcrepo-data: {}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(compose) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "field.storage.media.field_media_file.yml"), []byte("settings:\n  uri_scheme: fedora\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(media field) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "drupal", "web", "robots.txt"), []byte("User-agent: *\nDisallow: /cantaloupe/*\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(robots) error = %v", err)
+	}
+
+	if err := Apply(Options{
+		Path:              projectDir,
+		Fcrepo:            FcrepoStateOff,
+		Blazegraph:        FcrepoStateOff,
+		IIIF:              IIIFTriplet,
+		ISLEFileSystemURI: PrivateISLEFileSystemURI,
+	}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	composeData, err := os.ReadFile(filepath.Join(projectDir, "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("ReadFile(compose) error = %v", err)
+	}
+	compose := string(composeData)
+	if !strings.Contains(compose, "\n  triplet:\n") {
+		t.Fatalf("expected triplet service, got:\n%s", compose)
+	}
+	for _, absent := range []string{"\n  fcrepo:\n", "\n  blazegraph:\n", "fcrepo-data", "blazegraph-data", "condition: service_healthy", "source: fcrepo-data"} {
+		if strings.Contains(compose, absent) {
+			t.Fatalf("expected %q removed, got:\n%s", absent, compose)
+		}
+	}
+
+	mediaField, err := os.ReadFile(filepath.Join(configDir, "field.storage.media.field_media_file.yml"))
+	if err != nil {
+		t.Fatalf("ReadFile(media field) error = %v", err)
+	}
+	if !strings.Contains(string(mediaField), "uri_scheme: private") && !strings.Contains(string(mediaField), `uri_scheme: "private"`) {
+		t.Fatalf("expected private uri_scheme, got:\n%s", string(mediaField))
+	}
+
+	robots, err := os.ReadFile(filepath.Join(projectDir, "drupal", "web", "robots.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile(robots) error = %v", err)
+	}
+	if !strings.Contains(string(robots), "Disallow: /iiif/*") {
+		t.Fatalf("expected IIIF robots rule, got:\n%s", string(robots))
+	}
+}
+
 func TestApplyBlazegraphOff(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/create/iiif.go
+++ b/pkg/create/iiif.go
@@ -90,6 +90,7 @@ func normalizeIIIFOptions(opts Options) Options {
 	if opts.DrupalRootfs == "" {
 		opts.DrupalRootfs = DefaultDrupalRootfs
 	}
+	opts.DrupalRootfs = resolveProjectDrupalRootfs(opts.Path, opts.DrupalRootfs)
 	if opts.IIIF == "" {
 		opts.IIIF = IIIFCantaloupe
 	}
@@ -532,7 +533,8 @@ func writeProjectFile(projectDir, rel, contents string) error {
 }
 
 func updateRobotsIIIF(projectDir, drupalRootfs string, enabled bool) error {
-	path := filepath.Join(projectDir, drupalRootfs, "web", "robots.txt")
+	layout := corecomponent.ResolveDrupalLayout(projectDir, resolveProjectDrupalRootfs(projectDir, drupalRootfs))
+	path := filepath.Join(layout.Root, "web", "robots.txt")
 	data, err := os.ReadFile(path) // #nosec G304 -- robots path is resolved inside the selected project.
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

Fixes the ISLE create smoke path for the current template layout.

- Allows `sitectl-isle` to resolve the active Drupal root from the checked-out project instead of assuming the legacy `drupal/rootfs/var/www/drupal` layout.
- Keeps explicit `--drupal-rootfs` behavior intact for older/custom layouts.
- Fixes initial git bootstrap in generated checkouts by passing `safe.directory`.
- Adds regression coverage for `--fcrepo off --blazegraph off --iiif triplet` against the current `drupal/config/sync` layout.