### PR TITLE
Use standard ingress env for app URLs

### DIFF
--- a/cmd/component_review.go
+++ b/cmd/component_review.go
@@ -74,19 +74,33 @@ func runComponentReconcile(cmd *cobra.Command, opts componentReconcileOptions) e
 	if err != nil {
 		return err
 	}
-	if ctx.DockerHostType != config.ContextLocal {
-		return fmt.Errorf("component review is local-only; context %q is %q", ctx.Name, ctx.DockerHostType)
-	}
 	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, opts.CodebaseRootfs, opts.DrupalRootfs)
 	if err != nil {
 		return err
 	}
 
-	statuses, err := detectComponentViewsForContext(ctx, rootfs)
+	componentName := strings.TrimSpace(opts.ComponentName)
+	remoteContext := ctx.DockerHostType != config.ContextLocal
+	if remoteContext && !opts.Report {
+		if componentName == "" || !remoteComponentSetAllowed(componentName) {
+			return fmt.Errorf("component review apply is local-only for %q; context %q is %q", componentName, ctx.Name, ctx.DockerHostType)
+		}
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: modifying remote project files directly; commit and review these changes through version control before promoting them.")
+	}
+
+	var statuses []componentView
+	if remoteContext && componentName != "" {
+		def, ok := componentDefinitions()[componentName]
+		if !ok {
+			return fmt.Errorf("unknown component %q", componentName)
+		}
+		statuses, err = detectComponentViewsForDefinitions(ctx, rootfs, def)
+	} else {
+		statuses, err = detectComponentViewsForContext(ctx, rootfs)
+	}
 	if err != nil {
 		return err
 	}
-	componentName := strings.TrimSpace(opts.ComponentName)
 	if strings.TrimSpace(componentName) != "" {
 		for _, status := range statuses {
 			if status.Name == componentName {
@@ -122,6 +136,24 @@ func runComponentReconcile(cmd *cobra.Command, opts componentReconcileOptions) e
 		return err
 	}
 	decisions := convertComponentReviewDecisions(rawDecisions)
+	if remoteContext {
+		if err := applyRemoteComponentReviewDecision(ctx, componentName, decisions[componentName]); err != nil {
+			return err
+		}
+		for _, status := range statuses {
+			decision := decisions[status.Name]
+			fmt.Fprintf(cmd.OutOrStdout(), "%s: %s", status.Name, reviewDecisionLabel(decision))
+			if strings.TrimSpace(decision.TLSMode) != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), " (%s)", decision.TLSMode)
+			} else if strings.TrimSpace(decision.TrustedIPs) != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), " (%s)", decision.TrustedIPs)
+			} else if strings.TrimSpace(decision.MaxUploadSize) != "" || strings.TrimSpace(decision.UploadTimeout) != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), " (%s, %s)", uploadLimitValue(map[string]string{"max-upload-size": decision.MaxUploadSize}, "max-upload-size"), uploadLimitValue(map[string]string{"upload-timeout": decision.UploadTimeout}, "upload-timeout"))
+			}
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+		return nil
+	}
 	if strings.TrimSpace(componentName) != "" {
 		decisions = mergeCurrentComponentReviewDecisions(ctx, rootfs, decisions)
 	}
@@ -145,6 +177,17 @@ func runComponentReconcile(cmd *cobra.Command, opts componentReconcileOptions) e
 		fmt.Fprintln(cmd.OutOrStdout())
 	}
 	return nil
+}
+
+func applyRemoteComponentReviewDecision(ctx *config.Context, componentName string, decision componentReviewDecision) error {
+	switch componentName {
+	case coretraefik.IngressName:
+		return applyIngressReviewDecision(ctx, decision)
+	case coredevmode.Name:
+		return applyDevModeReviewDecision(ctx, decision)
+	default:
+		return fmt.Errorf("component review apply is local-only for %q; context %q is %q", componentName, ctx.Name, ctx.DockerHostType)
+	}
 }
 
 func mergeCurrentComponentReviewDecisions(ctx *config.Context, drupalRootfs string, decisions map[string]componentReviewDecision) map[string]componentReviewDecision {

--- a/cmd/component_review_test.go
+++ b/cmd/component_review_test.go
@@ -135,8 +135,8 @@ func TestRunComponentReviewAppliesSelectedStates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(docker-compose.yml) error = %v", err)
 	}
-	if !strings.Contains(string(composeText), `DRUPAL_ENABLE_HTTPS: "true"`) ||
-		!strings.Contains(string(composeText), `DRUPAL_DEFAULT_SITE_URL: "https://repo.example.org"`) ||
+	if !strings.Contains(string(composeText), `INGRESS_HOSTNAMES: "repo.example.org,localhost,127.0.0.1,::1"`) ||
+		!strings.Contains(string(composeText), `INGRESS_SCHEME: "https"`) ||
 		!strings.Contains(string(composeText), "--certificatesResolvers.letsencrypt.acme.email=admin@example.org") {
 		t.Fatalf("expected prod letsencrypt settings, got:\n%s", string(composeText))
 	}

--- a/cmd/component_set.go
+++ b/cmd/component_set.go
@@ -58,9 +58,6 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 	if err != nil {
 		return err
 	}
-	if ctx.DockerHostType != config.ContextLocal {
-		return fmt.Errorf("component changes are local-only; context %q is %q", ctx.Name, ctx.DockerHostType)
-	}
 	rootfs, err := resolveCodebaseRootfsForContext(cmd, ctx, opts.CodebaseRootfs, opts.DrupalRootfs)
 	if err != nil {
 		return err
@@ -81,6 +78,13 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 	if !ok {
 		return fmt.Errorf("unknown component %q", name)
 	}
+	remoteContext := ctx.DockerHostType != config.ContextLocal
+	if remoteContext {
+		if !remoteComponentSetAllowed(name) {
+			return fmt.Errorf("component %q changes are local-only; context %q is %q", name, ctx.Name, ctx.DockerHostType)
+		}
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: modifying remote project files directly; commit and review these changes through version control before promoting them.")
+	}
 	if disposition != "" {
 		disposition, err = corecomponent.ResolveAllowedDisposition(def.AllowedDispositions, disposition)
 		if err != nil {
@@ -89,7 +93,12 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 		state = corecomponent.DispositionToState(disposition)
 	}
 
-	statuses, err := detectComponentViewsForContext(ctx, rootfs)
+	var statuses []componentView
+	if remoteContext {
+		statuses, err = detectComponentViewsForDefinitions(ctx, rootfs, def)
+	} else {
+		statuses, err = detectComponentViewsForContext(ctx, rootfs)
+	}
 	if err != nil {
 		return err
 	}
@@ -218,6 +227,15 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 	}
 	fmt.Fprintln(cmd.OutOrStdout())
 	return nil
+}
+
+func remoteComponentSetAllowed(name string) bool {
+	switch name {
+	case coretraefik.IngressName, coredevmode.Name:
+		return true
+	default:
+		return false
+	}
 }
 
 func componentDefinitions() map[string]corecomponent.Definition {
@@ -378,12 +396,15 @@ func isleIngressComponent() (corecomponent.ComposeServiceComponent, error) {
 			"triplet":    "{domain}",
 			"cantaloupe": "{domain}",
 		},
+		AppEnvDeletes: []string{
+			"DRUPAL_DEFAULT_SITE_URL",
+			"DRUPAL_ENABLE_HTTPS",
+			"DRUPAL_TRUSTED_HOST_PATTERNS",
+			"DRUSH_OPTIONS_URI",
+		},
 		ServiceEnvTemplates: map[string]map[string]string{
 			"drupal": {
 				"DRUPAL_DEFAULT_CANTALOUPE_URL": "{base_url}/iiif/3",
-				"DRUPAL_DEFAULT_SITE_URL":       "{base_url}",
-				"DRUPAL_ENABLE_HTTPS":           "{https_enabled}",
-				"DRUSH_OPTIONS_URI":             "{base_url}",
 			},
 			"fcrepo": {
 				"FCREPO_ALLOW_EXTERNAL_DRUPAL": "{base_url}/",
@@ -702,7 +723,7 @@ func resolveComponentSetFollowUps(cmd *cobra.Command, def corecomponent.Definiti
 	for _, spec := range def.FollowUpsForDisposition(disposition) {
 		flagName := componentSetFollowUpSpecFlagName(def.Name, spec)
 		switch {
-		case spec.Name == "acme-email" && def.Name == coretraefik.IngressName && resolvedIngressMode(options, view, def) != coretraefik.IngressModeHTTPSLetsEncrypt:
+		case spec.Name == "acme-email" && def.Name == coretraefik.IngressName && !coretraefik.IngressModeRequiresACMEEmail(resolvedIngressMode(options, view, def)):
 			options[spec.Name] = strings.TrimSpace(view.FollowUpValues[spec.Name])
 		case cmd != nil && cmd.Flags().Lookup(flagName) != nil && cmd.Flags().Changed(flagName):
 			if spec.MultiValue {

--- a/cmd/component_set_test.go
+++ b/cmd/component_set_test.go
@@ -757,8 +757,8 @@ func TestRunComponentSetConfiguresIngressLetsEncrypt(t *testing.T) {
 	composePath := filepath.Join(projectDir, "docker-compose.yml")
 	compose := readFileForTest(t, composePath)
 	for _, want := range []string{
-		`DRUPAL_ENABLE_HTTPS: "true"`,
-		`DRUPAL_DEFAULT_SITE_URL: "https://repo.example.org"`,
+		`INGRESS_HOSTNAMES: "repo.example.org,localhost,127.0.0.1,::1"`,
+		`INGRESS_SCHEME: "https"`,
 		`DRUPAL_DEFAULT_FCREPO_URL: "http://fcrepo:8080/fcrepo/rest/"`,
 		`FCREPO_ALLOW_EXTERNAL_DRUPAL: "https://repo.example.org/"`,
 		"--entryPoints.https.address=:443",
@@ -838,7 +838,7 @@ services:
 
 	ctx := &config.Context{ProjectDir: projectDir}
 	if err := applyISLEIngressFiles(ctx, map[string]string{
-		"mode":   coretraefik.IngressModeHTTPSDefault,
+		"mode":   coretraefik.IngressModeHTTPSCustom,
 		"domain": "repo.example.org",
 	}); err != nil {
 		t.Fatalf("applyISLEIngressFiles() error = %v", err)
@@ -848,6 +848,9 @@ services:
 	want := `DRUPAL_DEFAULT_FCREPO_URL: "http://fcrepo:8080/fcrepo/rest/"`
 	if !strings.Contains(compose, want) {
 		t.Fatalf("expected fcrepo URL %q, got:\n%s", want, compose)
+	}
+	if strings.Contains(compose, "drupal.internal") {
+		t.Fatalf("expected non-local ingress to omit drupal.internal, got:\n%s", compose)
 	}
 }
 
@@ -877,13 +880,20 @@ services:
 
 	compose := readFileForTest(t, filepath.Join(projectDir, "docker-compose.yml"))
 	for _, want := range []string{
-		`DRUPAL_DEFAULT_SITE_URL: http://localhost`,
-		`DRUSH_OPTIONS_URI: "http://drupal.internal"`,
-		`DRUPAL_TRUSTED_HOST_PATTERNS: "^localhost$,^drupal\\.internal$"`,
+		`INGRESS_HOSTNAMES: "localhost,127.0.0.1,::1,drupal.internal"`,
 		`FCREPO_ALLOW_EXTERNAL_DRUPAL: "http://drupal.internal/"`,
 	} {
 		if !strings.Contains(compose, want) {
 			t.Fatalf("expected compose to contain %q, got:\n%s", want, compose)
+		}
+	}
+	for _, notWant := range []string{
+		`DRUPAL_DEFAULT_SITE_URL`,
+		`DRUSH_OPTIONS_URI`,
+		`DRUPAL_TRUSTED_HOST_PATTERNS`,
+	} {
+		if strings.Contains(compose, notWant) {
+			t.Fatalf("expected compose not to contain %q, got:\n%s", notWant, compose)
 		}
 	}
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -293,23 +294,27 @@ func runCreateCommand(cmd *cobra.Command, req createRequest) error {
 	req.ContextName = ctx.Name
 	req.Path = ctx.ProjectDir
 	req.Apply.Path = ctx.ProjectDir
-	cloned, err := ensureClonedCheckout(progress, req)
+	cloned, err := ensureClonedCheckoutForContext(progress, ctx, req)
 	if err != nil {
 		return err
 	}
 	if cloned {
-		if err := createBootstrapCheckout(progress, ctx.ProjectDir); err != nil {
+		if err := bootstrapCheckoutForContext(progress, ctx); err != nil {
 			return err
 		}
 	}
 	fmt.Fprintln(progress)
 	fmt.Fprintln(progress, corecomponent.RenderSection("Template configuration", "Applying requested ISLE component and topology choices."))
 	fmt.Fprintln(progress)
-	if err := runWithSpinner(progress, "Applying ISLE options", func() error {
-		return createApply(req.Apply)
-	}); err != nil {
-		printCreateFailureSummary(summary, req)
-		return err
+	if ctx.DockerHostType == config.ContextRemote {
+		fmt.Fprintln(progress, "Warning: remote ISLE create leaves template-level Drupal/codebase rewrites to version-controlled local changes.")
+	} else {
+		if err := runWithSpinner(progress, "Applying ISLE options", func() error {
+			return createApply(req.Apply)
+		}); err != nil {
+			printCreateFailureSummary(summary, req)
+			return err
+		}
 	}
 	if err := applyCreateIngress(ctx, req); err != nil {
 		printCreateFailureSummary(summary, req)
@@ -324,7 +329,10 @@ func runCreateCommand(cmd *cobra.Command, req createRequest) error {
 		return err
 	}
 	if !req.ImageOverrides.Empty() {
-		if err := plugin.ApplyComposeImageOverrides(ctx.ProjectDir, req.ImageOverrides); err != nil {
+		if ctx.DockerHostType == config.ContextRemote {
+			fmt.Fprintln(progress, "Warning: modifying remote project files directly; commit and review these changes through version control before promoting them.")
+		}
+		if err := plugin.ApplyComposeImageOverridesContext(ctx, req.ImageOverrides); err != nil {
 			printCreateFailureSummary(summary, req)
 			return err
 		}
@@ -442,12 +450,12 @@ func refreshCreateContextComposeMetadata(ctx *config.Context) error {
 	if projectDir == "" {
 		return nil
 	}
-	composeProjectName := config.DetectComposeProjectName(projectDir)
+	composeProjectName := config.DetectContextComposeProjectName(ctx)
 	if strings.TrimSpace(composeProjectName) == "" || composeProjectName == ctx.ComposeProjectName {
 		return nil
 	}
 	ctx.ComposeProjectName = composeProjectName
-	ctx.ComposeNetwork = config.DetectComposeNetworkName(projectDir, composeProjectName)
+	ctx.ComposeNetwork = config.DetectContextComposeNetwork(ctx)
 	return config.SaveContext(ctx, false)
 }
 
@@ -500,7 +508,7 @@ This will completely stop and destroy the setup.`, shellPath(ctx.ProjectDir), cl
 			if _, err := fmt.Fprintf(logFile, "Running %s\n", commandText); err != nil {
 				return err
 			}
-			if err := createRunProjectCommand(ctx.ProjectDir, logFile, logFile, "bash", "-lc", commandText); err != nil {
+			if err := runCreateProjectShellCommand(ctx, logFile, logFile, commandText); err != nil {
 				return fmt.Errorf("run %s: %w", commandText, err)
 			}
 		}
@@ -653,6 +661,97 @@ func ensureClonedCheckout(out io.Writer, req createRequest) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func ensureClonedCheckoutForContext(out io.Writer, ctx *config.Context, req createRequest) (bool, error) {
+	if ctx == nil || ctx.DockerHostType != config.ContextRemote {
+		return ensureClonedCheckout(out, req)
+	}
+	repoURL := strings.TrimSpace(req.TemplateRepo)
+	branch := strings.TrimSpace(req.TemplateBranch)
+	projectDir := strings.TrimSpace(ctx.ProjectDir)
+	if repoURL == "" {
+		return false, fmt.Errorf("template repo cannot be empty")
+	}
+	if projectDir == "" {
+		return false, fmt.Errorf("project directory cannot be empty")
+	}
+
+	var present bytes.Buffer
+	checkCommand := fmt.Sprintf("if [ -d %s ] && [ -n \"$(ls -A %s 2>/dev/null)\" ]; then echo present; fi", plugin.ShellQuote(projectDir), plugin.ShellQuote(projectDir))
+	if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, "", &present, io.Discard, checkCommand); err == nil && strings.TrimSpace(present.String()) == "present" {
+		return false, nil
+	}
+	if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, "", io.Discard, io.Discard, fmt.Sprintf("mkdir -p %s", plugin.ShellQuote(filepath.Dir(projectDir)))); err != nil {
+		return false, fmt.Errorf("create parent directory for %q: %w", projectDir, err)
+	}
+
+	fmt.Fprintln(out, corecomponent.RenderSection(
+		"Template checkout",
+		fmt.Sprintf("Cloning %s at %s into %s on %s.", repoURL, helpers.FirstNonEmpty(branch, "default branch"), projectDir, ctx.SSHHostname),
+	))
+	fmt.Fprintln(out)
+	cloneArgs := []string{"git", "clone"}
+	if branch != "" {
+		cloneArgs = append(cloneArgs, "--branch", branch)
+	}
+	cloneArgs = append(cloneArgs, repoURL, projectDir)
+	initBranch := helpers.FirstNonEmpty(branch, "main")
+	cloneCommand := strings.Join([]string{
+		plugin.ShellJoin(cloneArgs),
+		"rm -rf " + plugin.ShellQuote(filepath.Join(projectDir, ".git")),
+		plugin.ShellJoin([]string{"git", "-C", projectDir, "init", "-b", initBranch}),
+	}, " && ")
+	if err := runWithSpinner(out, "Cloning template repository", func() error {
+		return commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, "", io.Discard, io.Discard, cloneCommand)
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func bootstrapCheckoutForContext(out io.Writer, ctx *config.Context) error {
+	if ctx == nil || ctx.DockerHostType != config.ContextRemote {
+		return createBootstrapCheckout(out, ctx.ProjectDir)
+	}
+	projectDir := strings.TrimSpace(ctx.ProjectDir)
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, corecomponent.RenderSection(
+		"Git bootstrap",
+		fmt.Sprintf("Recording the pristine template checkout in %s before applying any sitectl-isle changes.", projectDir),
+	))
+	fmt.Fprintln(out)
+	return runWithSpinner(out, "Creating initial git commit", func() error {
+		safeDirectory := "safe.directory=" + projectDir
+		if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, projectDir, io.Discard, io.Discard, plugin.ShellJoin([]string{"git", "-c", safeDirectory, "add", "."})); err != nil {
+			return fmt.Errorf("stage initial checkout: %w", err)
+		}
+		if err := commandSDK.RunComposeProjectCommandContext(
+			context.Background(),
+			ctx,
+			projectDir,
+			io.Discard,
+			io.Discard,
+			plugin.ShellJoin([]string{
+				"git",
+				"-c", safeDirectory,
+				"-c", "user.name=sitectl-isle",
+				"-c", "user.email=sitectl-isle@localhost",
+				"commit",
+				"-m", "initial commit.",
+			}),
+		); err != nil {
+			return fmt.Errorf("create initial commit: %w", err)
+		}
+		return nil
+	})
+}
+
+func runCreateProjectShellCommand(ctx *config.Context, stdout, stderr io.Writer, commandText string) error {
+	if ctx != nil && ctx.DockerHostType == config.ContextRemote {
+		return commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, ctx.ProjectDir, stdout, stderr, commandText)
+	}
+	return createRunProjectCommand(ctx.ProjectDir, stdout, stderr, "bash", "-lc", commandText)
 }
 
 func bootstrapCheckout(out io.Writer, projectDir string) error {

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -136,7 +136,7 @@ func TestResolveCreateRequestSkipsPromptForExplicitFlags(t *testing.T) {
 	_ = cmd.Flags().Set("iiif-upstream-url", "https://iiif.example.org")
 	_ = cmd.Flags().Set("codebase", "git-root")
 	_ = cmd.Flags().Set("ingress", "enabled")
-	_ = cmd.Flags().Set("mode", coretraefik.IngressModeHTTPSDefault)
+	_ = cmd.Flags().Set("mode", coretraefik.IngressModeHTTPSCustom)
 	_ = cmd.Flags().Set("domain", "repo.example.org")
 	_ = cmd.Flags().Set("trusted-ip", "10.0.0.0/8")
 	_ = cmd.Flags().Set("trusted-ip", "203.0.113.4")
@@ -160,7 +160,7 @@ func TestResolveCreateRequestSkipsPromptForExplicitFlags(t *testing.T) {
 	if req.Apply.DerivativeServices["homarus"] != createpkg.DerivativeTopologyDistributed {
 		t.Fatalf("expected homarus distributed option, got %+v", req.Apply.DerivativeServices)
 	}
-	if req.IngressState != "on" || req.IngressMode != coretraefik.IngressModeHTTPSDefault || req.IngressDomain != "repo.example.org" || req.IngressTrustedIPs != "10.0.0.0/8,203.0.113.4" {
+	if req.IngressState != "on" || req.IngressMode != coretraefik.IngressModeHTTPSCustom || req.IngressDomain != "repo.example.org" || req.IngressTrustedIPs != "10.0.0.0/8,203.0.113.4" {
 		t.Fatalf("expected ingress enabled with overrides, got state=%q mode=%q domain=%q trusted=%q", req.IngressState, req.IngressMode, req.IngressDomain, req.IngressTrustedIPs)
 	}
 	if req.MaxUploadSize != "2G" || req.UploadTimeout != "10m" {

--- a/cmd/dev_mode.go
+++ b/cmd/dev_mode.go
@@ -47,7 +47,7 @@ func applyISLEDevMode(ctx *config.Context, enabled bool) error {
 
 func writeISLEDevModeTraefikOverride(ctx *config.Context) error {
 	overridePath := resolveEnvironmentOverridePath(ctx)
-	compose, err := corecomponent.LoadComposeFileOptional(overridePath)
+	compose, err := corecomponent.LoadComposeFileOptionalForContext(ctx, overridePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/libops/sitectl/pkg/config"
 	"github.com/libops/sitectl/pkg/healthcheck"
 	"github.com/libops/sitectl/pkg/plugin"
@@ -50,14 +53,96 @@ func (isleHealthcheckRunner) Run(cmd *cobra.Command, ctx *config.Context) ([]sit
 var _ plugin.HealthcheckRunner = isleHealthcheckRunner{}
 
 func isleDrupalPublicURL(ctx *config.Context) string {
-	target := healthcheck.PublicURLFromEnv(ctx, "http", "localhost")
+	target := isleDrupalURLFromServiceEnvironment(ctx)
+	if target == "" {
+		target = healthcheck.PublicURLFromEnv(ctx, "http", "localhost")
+	}
 	if traefikURL, ok, err := healthcheck.PublicURLFromTraefik(ctx, healthcheck.TraefikRouteOptions{
 		AppService:    "drupal",
 		Router:        "drupal",
 		DefaultScheme: "http",
 		DefaultDomain: "localhost",
-	}); err == nil && ok {
+	}); err == nil && ok && preferISLETraefikHealthcheckURL(target, traefikURL) {
 		target = traefikURL
 	}
 	return target
+}
+
+func isleDrupalURLFromServiceEnvironment(ctx *config.Context) string {
+	env, err := plugin.ContextServiceEnvironment(ctx, "drupal")
+	if err != nil {
+		return ""
+	}
+	scheme := "http"
+	domain := "localhost"
+	if ingressDomain := firstISLEIngressHostname(env["INGRESS_HOSTNAMES"]); ingressDomain != "" || strings.TrimSpace(env["INGRESS_SCHEME"]) != "" {
+		if strings.TrimSpace(env["INGRESS_SCHEME"]) != "" {
+			scheme = strings.TrimSpace(env["INGRESS_SCHEME"])
+		}
+		if ingressDomain != "" {
+			domain = ingressDomain
+		}
+	} else {
+		for _, key := range []string{"DRUPAL_DEFAULT_SITE_URL", "DRUSH_OPTIONS_URI"} {
+			parsedScheme, parsedDomain := schemeDomainFromRawURL(env[key])
+			if parsedDomain != "" {
+				if parsedScheme != "" {
+					scheme = parsedScheme
+				}
+				domain = parsedDomain
+				break
+			}
+		}
+		if strings.EqualFold(strings.TrimSpace(env["DRUPAL_ENABLE_HTTPS"]), "true") {
+			scheme = "https"
+		}
+	}
+	if strings.TrimSpace(domain) == "" {
+		return ""
+	}
+	return (&url.URL{Scheme: scheme, Host: domain, Path: "/"}).String()
+}
+
+func firstISLEIngressHostname(value string) string {
+	for _, hostname := range strings.Split(value, ",") {
+		hostname = strings.TrimSpace(hostname)
+		if hostname != "" {
+			return hostname
+		}
+	}
+	return ""
+}
+
+func preferISLETraefikHealthcheckURL(envURL, traefikURL string) bool {
+	envHost := healthcheckURLHostname(envURL)
+	traefikHost := healthcheckURLHostname(traefikURL)
+	if envHost != "" && !localHealthcheckHost(envHost) && localHealthcheckHost(traefikHost) {
+		return false
+	}
+	return true
+}
+
+func schemeDomainFromRawURL(raw string) (string, string) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Hostname() == "" {
+		return "", ""
+	}
+	host := parsed.Hostname()
+	if port := parsed.Port(); port != "" {
+		host = host + ":" + port
+	}
+	return parsed.Scheme, host
+}
+
+func healthcheckURLHostname(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+func localHealthcheckHost(host string) bool {
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }

--- a/cmd/ingress.go
+++ b/cmd/ingress.go
@@ -14,11 +14,19 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-const drupalFcrepoInternalURL = "http://fcrepo:8080/fcrepo/rest/"
+const (
+	drupalFcrepoInternalURL = "http://fcrepo:8080/fcrepo/rest/"
+	drupalInternalHostname  = "drupal.internal"
+)
 
 func applyISLEIngressFiles(ctx *config.Context, values map[string]string) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
+	}
+	if ctx.DockerHostType == "" {
+		localCtx := *ctx
+		localCtx.DockerHostType = config.ContextLocal
+		ctx = &localCtx
 	}
 	if err := applyISLEFcrepoIngressEnv(ctx, values); err != nil {
 		return err
@@ -28,7 +36,7 @@ func applyISLEIngressFiles(ctx *config.Context, values map[string]string) error 
 	data, err := ctx.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return createpkg.SyncBotMitigationBypass(ctx.ProjectDir)
+			return createpkg.SyncBotMitigationBypassContext(ctx)
 		}
 		return fmt.Errorf("read Triplet config: %w", err)
 	}
@@ -46,20 +54,30 @@ func applyISLEIngressFiles(ctx *config.Context, values map[string]string) error 
 	if err := ctx.WriteFile(path, updated); err != nil {
 		return err
 	}
-	return createpkg.SyncBotMitigationBypass(ctx.ProjectDir)
+	return createpkg.SyncBotMitigationBypassContext(ctx)
 }
 
 func applyISLEFcrepoIngressEnv(ctx *config.Context, values map[string]string) error {
-	compose, err := corecomponent.LoadComposeFile(ctx.ResolveProjectPath("docker-compose.yml"))
+	compose, err := corecomponent.LoadComposeFileForContext(ctx, ctx.ResolveProjectPath("docker-compose.yml"))
 	if err != nil {
 		return err
 	}
 	localFcrepo := compose.HasService("fcrepo") && ingressDomain(values) == coretraefik.DefaultIngressDomain
-	if err := createpkg.SyncLocalDrupalInternalIngress(ctx.ProjectDir, localFcrepo); err != nil {
+	if err := compose.SetServiceEnv("drupal", "INGRESS_HOSTNAMES", strings.Join(isleIngressHostnames(ctx, values, localFcrepo), ",")); err != nil {
 		return err
 	}
-	if err := compose.SetServiceEnv("drupal", "DRUPAL_TRUSTED_HOST_PATTERNS", createpkg.TrustedHostPatterns(ingressDomain(values), localFcrepo)); err != nil {
+	if err := createpkg.SyncLocalDrupalInternalIngressContext(ctx, localFcrepo); err != nil {
 		return err
+	}
+	for _, key := range []string{
+		"DRUPAL_DEFAULT_SITE_URL",
+		"DRUPAL_ENABLE_HTTPS",
+		"DRUPAL_TRUSTED_HOST_PATTERNS",
+		"DRUSH_OPTIONS_URI",
+	} {
+		if err := compose.DeleteServiceEnv("drupal", key); err != nil {
+			return err
+		}
 	}
 	if !compose.HasService("fcrepo") {
 		for _, key := range []string{
@@ -77,9 +95,6 @@ func applyISLEFcrepoIngressEnv(ctx *config.Context, values map[string]string) er
 		return err
 	}
 	if localFcrepo {
-		if err := compose.SetServiceEnv("drupal", "DRUSH_OPTIONS_URI", createpkg.LocalDrupalBaseURL); err != nil {
-			return err
-		}
 		if err := compose.SetServiceEnv("fcrepo", "FCREPO_ALLOW_EXTERNAL_DRUPAL", createpkg.LocalDrupalBaseURL+"/"); err != nil {
 			return err
 		}
@@ -87,18 +102,41 @@ func applyISLEFcrepoIngressEnv(ctx *config.Context, values map[string]string) er
 	return compose.Save()
 }
 
+func isleIngressHostnames(ctx *config.Context, values map[string]string, includeInternalDrupal bool) []string {
+	update := coretraefik.IngressAppUpdate{
+		Mode:   strings.TrimSpace(values["mode"]),
+		Domain: ingressDomain(values),
+		Scheme: ingressScheme(values),
+	}
+	hosts := coretraefik.SuggestedApplicationHosts(ctx, update)
+	if includeInternalDrupal {
+		hosts = appendUniqueISLEHostname(hosts, drupalInternalHostname)
+	}
+	return hosts
+}
+
+func appendUniqueISLEHostname(hosts []string, hostname string) []string {
+	hostname = strings.Trim(strings.TrimSpace(hostname), "[]")
+	if hostname == "" {
+		return hosts
+	}
+	for _, existing := range hosts {
+		if strings.EqualFold(existing, hostname) {
+			return hosts
+		}
+	}
+	return append(hosts, hostname)
+}
+
 func ingressBaseURL(values map[string]string) string {
 	return ingressScheme(values) + "://" + ingressDomain(values)
 }
 
 func ingressScheme(values map[string]string) string {
-	mode := strings.TrimSpace(values["mode"])
-	switch mode {
-	case coretraefik.IngressModeHTTPSDefault, coretraefik.IngressModeHTTPSLetsEncrypt:
+	if coretraefik.IngressModeUsesHTTPS(values["mode"]) {
 		return "https"
-	default:
-		return "http"
 	}
+	return "http"
 }
 
 func ingressDomain(values map[string]string) string {

--- a/cmd/ingress_routes.go
+++ b/cmd/ingress_routes.go
@@ -21,8 +21,7 @@ func (isleIngressRouteProvider) Routes(cmd *cobra.Command, ctx *config.Context) 
 	followUps := currentIngressFollowUps(ctx)
 	domain := firstIngressRouteValue(followUps["domain"], coretraefik.DefaultIngressDomain, "localhost")
 	scheme := "http"
-	switch strings.TrimSpace(followUps["mode"]) {
-	case coretraefik.IngressModeHTTPSDefault, coretraefik.IngressModeHTTPSLetsEncrypt:
+	if coretraefik.IngressModeUsesHTTPS(followUps["mode"]) {
 		scheme = "https"
 	}
 	routes := []plugin.IngressRoute{

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -110,11 +110,15 @@ func invokeSDKIncludedRPC(sdk *plugin.SDK, include string, req plugin.RPCRequest
 type componentView = corecomponent.ReviewView
 
 func detectComponentViewsForContext(siteCtx *config.Context, drupalRootfs string) ([]componentView, error) {
+	return detectComponentViewsForDefinitions(siteCtx, drupalRootfs, orderedComponentDefinitions()...)
+}
+
+func detectComponentViewsForDefinitions(siteCtx *config.Context, drupalRootfs string, defs ...corecomponent.Definition) ([]componentView, error) {
 	definitions := componentDefinitions()
 	sdkStatuses, err := corecomponent.DetectComponentStatuses(siteCtx, siteCtx.ProjectDir, corecomponent.DetectOptions{
 		ComposeRoot:  siteCtx.ProjectDir,
 		DrupalRootfs: drupalRootfs,
-	}, orderedComponentDefinitions()...)
+	}, defs...)
 	if err != nil {
 		return nil, err
 	}
@@ -185,14 +189,18 @@ func currentIngressFollowUps(siteCtx *config.Context) map[string]string {
 	if siteCtx == nil {
 		return followUps
 	}
-	compose, err := corecomponent.LoadComposeFile(filepath.Join(siteCtx.ProjectDir, "docker-compose.yml"))
+	compose, err := corecomponent.LoadComposeFileForContext(siteCtx, siteCtx.ResolveProjectPath("docker-compose.yml"))
 	if err != nil {
 		return followUps
 	}
 	command := composeServiceCommand(compose, "traefik")
+	tlsMode := composeServiceEnvValue(compose, "traefik", "SITECTL_TLS_MODE")
 	projectEnv := healthcheck.ProjectEnv(siteCtx)
-	followUps["mode"] = detectIngressMode(command)
+	followUps["mode"] = detectIngressMode(command, tlsMode)
 	if domain := domainFromTraefikRoute(siteCtx, projectEnv); domain != "" {
+		followUps["domain"] = domain
+	}
+	if domain := firstISLEIngressHostname(composeServiceEnvValue(compose, "drupal", "INGRESS_HOSTNAMES")); domain != "" && followUps["domain"] == "" {
 		followUps["domain"] = domain
 	}
 	if domain := domainFromServiceURL(composeServiceEnvValue(compose, "drupal", "DRUPAL_DEFAULT_SITE_URL"), projectEnv); domain != "" && followUps["domain"] == "" {
@@ -240,7 +248,10 @@ func domainFromTraefikRoute(siteCtx *config.Context, projectEnv map[string]strin
 	return domainFromServiceURL(publicURL, projectEnv)
 }
 
-func detectIngressMode(command string) string {
+func detectIngressMode(command, tlsMode string) string {
+	if mode, ok := coretraefik.NormalizeIngressMode(tlsMode); ok && mode != coretraefik.IngressModeHTTP {
+		return mode
+	}
 	if commandValueByPrefix(command, "--certificatesResolvers.letsencrypt.acme.email=") != "" ||
 		commandValueByPrefix(command, "--certificatesresolvers.letsencrypt.acme.email=") != "" {
 		return coretraefik.IngressModeHTTPSLetsEncrypt
@@ -248,7 +259,7 @@ func detectIngressMode(command string) string {
 	for _, line := range composeStringLines(command) {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "--entryPoints.https.address=") || strings.HasPrefix(line, "--entrypoints.https.address=") {
-			return coretraefik.IngressModeHTTPSDefault
+			return coretraefik.IngressModeHTTPSCustom
 		}
 	}
 	return coretraefik.IngressModeHTTP

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/libops/sitectl-isle
 go 1.26.1
 
 require (
-	github.com/libops/sitectl v0.35.1
+	github.com/libops/sitectl v0.35.3
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/libops/sitectl v0.35.0 h1:yH89aMG0lBKjbXv2uEMurvEfVzGjdhel+0wU3ICnY2o
 github.com/libops/sitectl v0.35.0/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
 github.com/libops/sitectl v0.35.1 h1:vAcrasIu8cUAbwK5ePr3/cebHxOkXA46ZEYJrod0eLg=
 github.com/libops/sitectl v0.35.1/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
+github.com/libops/sitectl v0.35.3 h1:CdA2yaXEeC/41xcOoyPQ2Ke2pYV4+T2bJAFXxOsa/O8=
+github.com/libops/sitectl v0.35.3/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
 github.com/lrstanley/bubblezone/v2 v2.0.0 h1:pMb9fHKs0slJF6OrzQ2hEgWusqyl9VU/S0UZ5hyh7ZA=
 github.com/lrstanley/bubblezone/v2 v2.0.0/go.mod h1:yV/QTjcm4Zu5cqvGvdHi7xVUfnB36w/SafOuDp57dgY=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=

--- a/pkg/create/apply.go
+++ b/pkg/create/apply.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	corecomponent "github.com/libops/sitectl/pkg/component"
+	"github.com/libops/sitectl/pkg/config"
 	coretraefik "github.com/libops/sitectl/pkg/services/traefik"
 	"gopkg.in/yaml.v3"
 )
@@ -260,38 +261,61 @@ func ApplyBotMitigation(projectDir, state string) error {
 }
 
 func SyncBotMitigationBypass(projectDir string) error {
-	path := filepath.Join(projectDir, filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
-	data, err := os.ReadFile(path) // #nosec G304 -- path is scoped to the selected project directory.
+	return SyncBotMitigationBypassContext(localProjectContext(projectDir))
+}
+
+func SyncBotMitigationBypassContext(ctx *config.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	path := ctx.ResolveProjectPath(filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
+	exists, err := ctx.FileExists(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
+		return fmt.Errorf("stat bot mitigation router config: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	data, err := ctx.ReadFile(path)
+	if err != nil {
 		return fmt.Errorf("read bot mitigation router config: %w", err)
 	}
-	return updateWorkbenchClientBypass(projectDir, strings.Contains(string(data), "captcha-protect"))
+	return updateWorkbenchClientBypassContext(ctx, strings.Contains(string(data), "captcha-protect"))
 }
 
 func SyncLocalDrupalInternalIngress(projectDir string, enabled bool) error {
-	routerPath := filepath.Join(projectDir, filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
-	if _, err := os.Stat(routerPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("stat local Drupal router config: %w", err)
-	}
-	if err := syncLocalDrupalTraefikAlias(projectDir, enabled); err != nil {
-		return err
-	}
-	return syncLocalDrupalRouter(projectDir, enabled)
+	return SyncLocalDrupalInternalIngressContext(localProjectContext(projectDir), enabled)
 }
 
-func syncLocalDrupalTraefikAlias(projectDir string, enabled bool) error {
-	path := filepath.Join(projectDir, "docker-compose.yml")
-	data, err := os.ReadFile(path) // #nosec G304 -- path is scoped to the selected project directory.
+func SyncLocalDrupalInternalIngressContext(ctx *config.Context, enabled bool) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	routerPath := ctx.ResolveProjectPath(filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
+	exists, err := ctx.FileExists(routerPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
+		return fmt.Errorf("stat local Drupal router config: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	if err := syncLocalDrupalTraefikAliasContext(ctx, enabled); err != nil {
+		return err
+	}
+	return syncLocalDrupalRouterContext(ctx, enabled)
+}
+
+func syncLocalDrupalTraefikAliasContext(ctx *config.Context, enabled bool) error {
+	path := ctx.ResolveProjectPath("docker-compose.yml")
+	exists, err := ctx.FileExists(path)
+	if err != nil {
+		return fmt.Errorf("stat docker-compose.yml: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	data, err := ctx.ReadFile(path)
+	if err != nil {
 		return fmt.Errorf("read docker-compose.yml: %w", err)
 	}
 	var root map[string]any
@@ -324,16 +348,20 @@ func syncLocalDrupalTraefikAlias(projectDir string, enabled bool) error {
 	if err != nil {
 		return fmt.Errorf("marshal docker-compose.yml: %w", err)
 	}
-	return os.WriteFile(path, updated, 0o644) // #nosec G306 -- generated project configuration is non-secret.
+	return ctx.WriteFile(path, updated)
 }
 
-func syncLocalDrupalRouter(projectDir string, enabled bool) error {
-	path := filepath.Join(projectDir, filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
-	data, err := os.ReadFile(path) // #nosec G304 -- path is scoped to the selected project directory.
+func syncLocalDrupalRouterContext(ctx *config.Context, enabled bool) error {
+	path := ctx.ResolveProjectPath(filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
+	exists, err := ctx.FileExists(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
+		return fmt.Errorf("stat local Drupal router config: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	data, err := ctx.ReadFile(path)
+	if err != nil {
 		return fmt.Errorf("read local Drupal router config: %w", err)
 	}
 	doc, err := corecomponent.LoadYAMLDocument(data)
@@ -355,7 +383,7 @@ func syncLocalDrupalRouter(projectDir string, enabled bool) error {
 		if err != nil {
 			return fmt.Errorf("marshal local Drupal router config: %w", err)
 		}
-		return os.WriteFile(path, updated, 0o644) // #nosec G306 -- generated project configuration is non-secret.
+		return ctx.WriteFile(path, updated)
 	}
 	router, err := localDrupalRouter(data)
 	if err != nil {
@@ -374,16 +402,24 @@ func syncLocalDrupalRouter(projectDir string, enabled bool) error {
 	if err != nil {
 		return fmt.Errorf("marshal local Drupal router config: %w", err)
 	}
-	return os.WriteFile(path, updated, 0o644) // #nosec G306 -- generated project configuration is non-secret.
+	return ctx.WriteFile(path, updated)
 }
 
 func updateWorkbenchClientBypass(projectDir string, enabled bool) error {
-	path := filepath.Join(projectDir, filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
-	data, err := os.ReadFile(path) // #nosec G304 -- path is scoped to the selected project directory.
+	return updateWorkbenchClientBypassContext(localProjectContext(projectDir), enabled)
+}
+
+func updateWorkbenchClientBypassContext(ctx *config.Context, enabled bool) error {
+	path := ctx.ResolveProjectPath(filepath.FromSlash(BotMitigationOptions().RouterConfigPath))
+	exists, err := ctx.FileExists(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
+		return fmt.Errorf("stat bot mitigation router config: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	data, err := ctx.ReadFile(path)
+	if err != nil {
 		return fmt.Errorf("read bot mitigation router config: %w", err)
 	}
 	doc, err := corecomponent.LoadYAMLDocument(data)
@@ -399,7 +435,7 @@ func updateWorkbenchClientBypass(projectDir string, enabled bool) error {
 		if err != nil {
 			return fmt.Errorf("marshal bot mitigation router config: %w", err)
 		}
-		return os.WriteFile(path, updated, 0o644) // #nosec G306 -- generated project configuration is non-secret.
+		return ctx.WriteFile(path, updated)
 	}
 	router, err := workbenchClientRouter(data)
 	if err != nil {
@@ -412,7 +448,14 @@ func updateWorkbenchClientBypass(projectDir string, enabled bool) error {
 	if err != nil {
 		return fmt.Errorf("marshal bot mitigation router config: %w", err)
 	}
-	return os.WriteFile(path, updated, 0o644) // #nosec G306 -- generated project configuration is non-secret.
+	return ctx.WriteFile(path, updated)
+}
+
+func localProjectContext(projectDir string) *config.Context {
+	return &config.Context{
+		DockerHostType: config.ContextLocal,
+		ProjectDir:     projectDir,
+	}
 }
 
 func workbenchClientRouter(data []byte) (map[string]any, error) {


### PR DESCRIPTION
## Summary
- rely on core ingress INGRESS_HOSTNAMES and INGRESS_SCHEME for public app URL/scheme settings
- remove plugin writes of legacy app URL/HTTPS env vars
- bump github.com/libops/sitectl to v0.35.3

## Tests
- GOWORK=off PATH=/usr/local/go/bin:$PATH GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod go test ./cmd