### PR TITLE
Mount fcrepo DB secret as DB_PASSWORD

### DIFF
--- a/pkg/create/apply.go
+++ b/pkg/create/apply.go
@@ -972,6 +972,7 @@ func fcrepoRestoreServiceBlock(image, commonMerge string) string {
     secrets:
       - source: DB_ROOT_PASSWORD
       - source: FCREPO_DB_PASSWORD
+        target: DB_PASSWORD
       - source: JWT_ADMIN_TOKEN
       - source: JWT_PUBLIC_KEY
     volumes:

--- a/pkg/create/apply_test.go
+++ b/pkg/create/apply_test.go
@@ -194,6 +194,7 @@ volumes: {}
 		`DRUSH_OPTIONS_URI: "http://drupal.internal"`,
 		`DRUPAL_TRUSTED_HOST_PATTERNS: "^localhost$,^drupal\\.internal$"`,
 		`FCREPO_ALLOW_EXTERNAL_DRUPAL: "http://drupal.internal/"`,
+		`target: DB_PASSWORD`,
 	} {
 		if !strings.Contains(compose, want) {
 			t.Fatalf("expected restored compose to contain %q, got:\n%s", want, compose)


### PR DESCRIPTION
## Summary
- mount the generated Fcrepo DB secret into restored fcrepo services as DB_PASSWORD
- add coverage so component restore keeps the normalized secret target

## Tests
- PATH=/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod go test ./pkg/create -run TestApplyFcrepoOnRestoresFcrepoAndMilliner
- git diff --check