### PR TITLE
Wire assistant options into ISLE dev mode

### DIFF
--- a/cmd/component_set.go
+++ b/cmd/component_set.go
@@ -93,6 +93,12 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 		state = corecomponent.DispositionToState(disposition)
 	}
 
+	assistantDevMode := name == coredevmode.Name && strings.TrimSpace(stateValue) == "" && componentSetBoolFlagValue(cmd, "assistant")
+	if assistantDevMode {
+		disposition = corecomponent.DispositionEnabled
+		state = corecomponent.StateOn
+	}
+
 	var statuses []componentView
 	if remoteContext {
 		statuses, err = detectComponentViewsForDefinitions(ctx, rootfs, def)
@@ -123,7 +129,7 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 		}
 	}
 
-	if strings.TrimSpace(stateValue) == "" {
+	if strings.TrimSpace(stateValue) == "" && !assistantDevMode {
 		status, ok := statusByName[name]
 		if !ok {
 			return fmt.Errorf("missing detected status for component %q", name)
@@ -171,7 +177,7 @@ func runComponentSetWithOptions(cmd *cobra.Command, name, stateValue string, opt
 		return runIngressComponentSet(cmd, ctx, disposition, state, followUps)
 	}
 	if name == coredevmode.Name {
-		return runDevModeComponentSet(cmd, ctx, disposition, state)
+		return runDevModeComponentSet(cmd, ctx, disposition, state, followUps)
 	}
 	if name == coretraefik.BotMitigationName {
 		return runBotMitigationComponentSet(cmd, ctx, disposition, state)
@@ -435,13 +441,13 @@ func uploadLimitValue(values map[string]string, key string) string {
 	}
 }
 
-func runDevModeComponentSet(cmd *cobra.Command, ctx *config.Context, disposition corecomponent.Disposition, state corecomponent.State) error {
+func runDevModeComponentSet(cmd *cobra.Command, ctx *config.Context, disposition corecomponent.Disposition, state corecomponent.State, followUps map[string]string) error {
 	component, err := isleDevModeComponent()
 	if err != nil {
 		return err
 	}
 	manager := corecomponent.NewManager(ctx)
-	spec := component.SpecForWithOptions(state, nil)
+	spec := component.SpecForWithOptions(state, followUps)
 	switch state {
 	case corecomponent.StateOn:
 		if err := manager.EnableComponentWithOptions(cmd.Context(), spec, corecomponent.ApplyOptions{Yolo: true}); err != nil {
@@ -708,6 +714,8 @@ func addComponentSetFollowUpFlags(cmd *cobra.Command, defs []corecomponent.Defin
 			}
 			if followUp.MultiValue {
 				cmd.Flags().StringArray(flagName, corecomponent.SplitFollowUpValues(followUp.DefaultValue), usage)
+			} else if followUp.BoolValue {
+				cmd.Flags().Bool(flagName, corecomponent.FollowUpBoolDefault(followUp), usage)
 			} else {
 				cmd.Flags().String(flagName, strings.TrimSpace(followUp.DefaultValue), usage)
 			}
@@ -730,7 +738,13 @@ func resolveComponentSetFollowUps(cmd *cobra.Command, def corecomponent.Definiti
 		case spec.Name == "acme-email" && def.Name == coretraefik.IngressName && !coretraefik.IngressModeRequiresACMEEmail(resolvedIngressMode(options, view, def)):
 			options[spec.Name] = strings.TrimSpace(view.FollowUpValues[spec.Name])
 		case cmd != nil && cmd.Flags().Lookup(flagName) != nil && cmd.Flags().Changed(flagName):
-			if spec.MultiValue {
+			if spec.BoolValue {
+				value, err := cmd.Flags().GetBool(flagName)
+				if err != nil {
+					return nil, err
+				}
+				options[spec.Name] = corecomponent.FormatFollowUpBool(value)
+			} else if spec.MultiValue {
 				values, err := cmd.Flags().GetStringArray(flagName)
 				if err != nil {
 					return nil, err
@@ -748,7 +762,9 @@ func resolveComponentSetFollowUps(cmd *cobra.Command, def corecomponent.Definiti
 			if defaultValue == "" {
 				defaultValue = strings.TrimSpace(spec.DefaultValue)
 			}
-			if spec.MultiValue {
+			if spec.BoolValue {
+				options[spec.Name] = corecomponent.FormatFollowUpBool(corecomponent.FollowUpBoolDefault(spec))
+			} else if spec.MultiValue {
 				options[spec.Name] = corecomponent.NormalizeFollowUpValue(defaultValue)
 			} else {
 				options[spec.Name] = defaultValue
@@ -799,6 +815,14 @@ func componentSetFollowUpSpecFlagName(componentName string, followUp corecompone
 		return strings.TrimSpace(followUp.FlagName)
 	}
 	return componentSetFollowUpFlagName(componentName, followUp.Name)
+}
+
+func componentSetBoolFlagValue(cmd *cobra.Command, flagName string) bool {
+	if cmd == nil || strings.TrimSpace(flagName) == "" || cmd.Flags().Lookup(flagName) == nil || !cmd.Flags().Changed(flagName) {
+		return false
+	}
+	value, err := cmd.Flags().GetBool(flagName)
+	return err == nil && value
 }
 
 func resolveComponentSetStateValue(cmd *cobra.Command, args []string) (string, error) {

--- a/cmd/component_set_test.go
+++ b/cmd/component_set_test.go
@@ -1023,6 +1023,50 @@ func TestRunComponentSetTogglesDevMode(t *testing.T) {
 	}
 }
 
+func TestRunComponentSetDevModeAssistantImpliesEnabled(t *testing.T) {
+	projectDir := t.TempDir()
+	writeISLEOnFixture(t, projectDir)
+
+	oldStatusPath := statusPath
+	oldDrupalRootfs := statusDrupalRootfs
+	oldYolo := componentSetYolo
+	oldPromptChoice := componentPromptChoice
+	t.Cleanup(func() {
+		statusPath = oldStatusPath
+		statusDrupalRootfs = oldDrupalRootfs
+		componentSetYolo = oldYolo
+		componentPromptChoice = oldPromptChoice
+	})
+
+	statusPath = projectDir
+	statusDrupalRootfs = createpkg.DefaultDrupalRootfs
+	componentSetYolo = true
+
+	cmd := newComponentSetTestCommand()
+	if err := cmd.Flags().Set("assistant", "true"); err != nil {
+		t.Fatalf("Flags().Set(assistant) error = %v", err)
+	}
+	if err := cmd.Flags().Set("harness", "claude"); err != nil {
+		t.Fatalf("Flags().Set(harness) error = %v", err)
+	}
+	if err := runComponentSet(cmd, "dev-mode", ""); err != nil {
+		t.Fatalf("runComponentSet(dev-mode --assistant) error = %v", err)
+	}
+
+	override := readFileForTest(t, filepath.Join(projectDir, "docker-compose.override.yml"))
+	for _, want := range []string{
+		"cli-sandbox:",
+		"image: ghcr.io/libops/cli-sandbox:claude",
+		"- claude",
+		"- --dangerously-skip-permissions",
+		"./web/modules/custom:/var/www/drupal/web/modules/custom:z,rw",
+	} {
+		if !strings.Contains(override, want) {
+			t.Fatalf("expected override to contain %q, got:\n%s", want, override)
+		}
+	}
+}
+
 func TestRunComponentSetDistributesCantaloupeIIIF(t *testing.T) {
 	projectDir := t.TempDir()
 	writeISLEOnFixture(t, projectDir)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/libops/sitectl-isle
 go 1.26.1
 
 require (
-	github.com/libops/sitectl v0.35.3
+	github.com/libops/sitectl v0.35.8
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,10 @@ github.com/libops/sitectl v0.35.1 h1:vAcrasIu8cUAbwK5ePr3/cebHxOkXA46ZEYJrod0eLg
 github.com/libops/sitectl v0.35.1/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
 github.com/libops/sitectl v0.35.3 h1:CdA2yaXEeC/41xcOoyPQ2Ke2pYV4+T2bJAFXxOsa/O8=
 github.com/libops/sitectl v0.35.3/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
+github.com/libops/sitectl v0.35.8-0.20260703170832-874a4f93b124 h1:1GtPaqwMoRJFnUijc3qgQ8gwIPEXw17rMF80MpRdYzw=
+github.com/libops/sitectl v0.35.8-0.20260703170832-874a4f93b124/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
+github.com/libops/sitectl v0.35.8 h1:qQls8Ki7Lc8k/UGivqjVxxXWP/uYszwiWI/HrKDikDI=
+github.com/libops/sitectl v0.35.8/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
 github.com/lrstanley/bubblezone/v2 v2.0.0 h1:pMb9fHKs0slJF6OrzQ2hEgWusqyl9VU/S0UZ5hyh7ZA=
 github.com/lrstanley/bubblezone/v2 v2.0.0/go.mod h1:yV/QTjcm4Zu5cqvGvdHi7xVUfnB36w/SafOuDp57dgY=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=


### PR DESCRIPTION
## Summary
- pass dev-mode follow-up options through ISLE's custom component set path
- let --assistant imply enabled dev-mode when no explicit state is provided
- verify the cli-sandbox service receives ISLE codebase mounts

## Tests
- go test ./cmd