### PR TITLE
Fix Isle create compose path rewriting

### DIFF
--- a/cmd/component_set_test.go
+++ b/cmd/component_set_test.go
@@ -1056,7 +1056,7 @@ func TestRunComponentSetDevModeAssistantImpliesEnabled(t *testing.T) {
 	override := readFileForTest(t, filepath.Join(projectDir, "docker-compose.override.yml"))
 	for _, want := range []string{
 		"cli-sandbox:",
-		"image: ghcr.io/libops/cli-sandbox:claude",
+		"image: ${SITECTL_ASSISTANT_IMAGE:-ghcr.io/libops/cli-sandbox:claude}",
 		"- claude",
 		"- --dangerously-skip-permissions",
 		"./web/modules/custom:/var/www/drupal/web/modules/custom:z,rw",

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -40,6 +40,7 @@ var (
 	createRunProjectCommand  = defaultRunProjectCommand
 	createBootstrapCheckout  = bootstrapCheckout
 	createRunStartup         = runStartup
+	createRewriteCommand     = rewriteCreateProjectShellCommand
 	createRefreshContext     = refreshCreateContextComposeMetadata
 	createPrepareStartup     = prepareCreateStartup
 	createCheckPrereqs       = checkPrereqs
@@ -504,6 +505,7 @@ This will completely stop and destroy the setup.`, shellPath(ctx.ProjectDir), cl
 			if commandText == "" {
 				continue
 			}
+			commandText = createRewriteCommand(ctx, commandText)
 			commandText = shellEnvPrefix(startupEnv) + commandText
 			if _, err := fmt.Fprintf(logFile, "Running %s\n", commandText); err != nil {
 				return err
@@ -752,6 +754,13 @@ func runCreateProjectShellCommand(ctx *config.Context, stdout, stderr io.Writer,
 		return commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, ctx.ProjectDir, stdout, stderr, commandText)
 	}
 	return createRunProjectCommand(ctx.ProjectDir, stdout, stderr, "bash", "-lc", commandText)
+}
+
+func rewriteCreateProjectShellCommand(ctx *config.Context, commandText string) string {
+	if ctx == nil {
+		return commandText
+	}
+	return ctx.DockerComposeShellCommand(commandText)
 }
 
 func bootstrapCheckout(out io.Writer, projectDir string) error {

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -908,9 +908,11 @@ func TestRunStartupPreparesLocalPortEnv(t *testing.T) {
 
 	oldPrepare := createPrepareStartup
 	oldRunProject := createRunProjectCommand
+	oldRewrite := createRewriteCommand
 	t.Cleanup(func() {
 		createPrepareStartup = oldPrepare
 		createRunProjectCommand = oldRunProject
+		createRewriteCommand = oldRewrite
 	})
 
 	var prepared bool
@@ -926,6 +928,14 @@ func TestRunStartupPreparesLocalPortEnv(t *testing.T) {
 	}
 
 	var commands []string
+	var rewrites []string
+	createRewriteCommand = func(ctx *config.Context, command string) string {
+		if strings.HasPrefix(command, "export ") {
+			t.Fatalf("expected compose rewrite before startup env prefix, got %q", command)
+		}
+		rewrites = append(rewrites, command)
+		return "rewritten(" + command + ")"
+	}
 	createRunProjectCommand = func(gotProjectDir string, stdout, stderr io.Writer, name string, args ...string) error {
 		if gotProjectDir != projectDir {
 			t.Fatalf("expected project dir %q, got %q", projectDir, gotProjectDir)
@@ -946,8 +956,11 @@ func TestRunStartupPreparesLocalPortEnv(t *testing.T) {
 	if len(commands) == 0 {
 		t.Fatal("expected startup commands")
 	}
+	if len(rewrites) != len(commands) {
+		t.Fatalf("expected every startup command to be rewritten before execution, got rewrites=%d commands=%d", len(rewrites), len(commands))
+	}
 	for _, command := range commands {
-		if !strings.HasPrefix(command, "export SITE_URL='http://localhost:8081' URI_SCHEME='http'; ") {
+		if !strings.HasPrefix(command, "export SITE_URL='http://localhost:8081' URI_SCHEME='http'; rewritten(") {
 			t.Fatalf("expected command to include local port env prefix, got %q", command)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/libops/sitectl-isle
 go 1.26.1
 
 require (
-	github.com/libops/sitectl v0.35.8
+	github.com/libops/sitectl v0.36.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/libops/sitectl v0.35.8-0.20260703170832-874a4f93b124 h1:1GtPaqwMoRJFn
 github.com/libops/sitectl v0.35.8-0.20260703170832-874a4f93b124/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
 github.com/libops/sitectl v0.35.8 h1:qQls8Ki7Lc8k/UGivqjVxxXWP/uYszwiWI/HrKDikDI=
 github.com/libops/sitectl v0.35.8/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
+github.com/libops/sitectl v0.36.0 h1:Gc+jN7L4tq2bbaGwchRshdnRqyr4oVzaipMA2TwoDvc=
+github.com/libops/sitectl v0.36.0/go.mod h1:uoXxmr3TSUYVgcWxwcFSOiDUmmKQW2ASr856dk/9yd8=
 github.com/lrstanley/bubblezone/v2 v2.0.0 h1:pMb9fHKs0slJF6OrzQ2hEgWusqyl9VU/S0UZ5hyh7ZA=
 github.com/lrstanley/bubblezone/v2 v2.0.0/go.mod h1:yV/QTjcm4Zu5cqvGvdHi7xVUfnB36w/SafOuDp57dgY=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=


### PR DESCRIPTION
Summary:
- Rewrite Isle startup docker compose commands before adding startup env exports so local Docker receives host-visible bind paths.
- Update the dev-mode assistant assertion for the env-overridable cli-sandbox image.

QA:
- go test ./...
- Isle plugin QA passed default HTTP and domain HTTP phases with host.docker.internal.