### PR TITLE
[skip-release] Separate release publication tokens

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   goreleaser:
-    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@2b484149fca1653d2bd48311929efca21f32214d # main
+    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@69fc4b92079cd51606e1d4757031c6e9b645bb5a # main
     permissions:
       contents: write
       id-token: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,7 @@ brews:
     repository:
       owner: libops
       name: homebrew
+      token: "{{ .Env.HOMEBREW_REPO_TOKEN }}"
     dependencies:
       - name: "libops/homebrew/sitectl"
       - name: "libops/homebrew/sitectl-drupal"


### PR DESCRIPTION
## Summary

- Pin the shared plugin release workflow to the validated two-token revision.
- Configure GoReleaser to use HOMEBREW_REPO_TOKEN only for Homebrew publication.

This keeps repository release publication on GITHUB_TOKEN and tap writes on the separately scoped Homebrew token as one atomic boundary change.

## Validation

- actionlint
- Race-enabled make test with the workspace disabled

No release workflow was invoked. Existing hosted PR integration checks, where present, run automatically.