### PR TITLE
[skip-release] Make release publication recoverable

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -2,6 +2,20 @@ name: goreleaser
 
 on:
   workflow_dispatch:
+    inputs:
+      release-mode:
+        description: Recovery mode; full is only valid from a new tag ref
+        required: true
+        type: choice
+        default: packages-only
+        options:
+          - packages-only
+          - homebrew-only
+          - full
+      release-version:
+        description: Existing vMAJOR.MINOR.PATCH tag for a recovery mode
+        required: false
+        type: string
   push:
     tags:
       - "*"
@@ -12,11 +26,13 @@ permissions:
 
 jobs:
   goreleaser:
-    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@69fc4b92079cd51606e1d4757031c6e9b645bb5a # main
+    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@66905c983e1ec673e936a7dc4b4d5c2ad0016b49 # main
     permissions:
       contents: write
       id-token: write
     secrets: inherit
     with:
-      go-version: "1.26.x"
+      go-version: "1.26.5"
+      release-mode: ${{ inputs.release-mode || 'full' }}
+      release-version: ${{ inputs.release-version }}
       package-name: sitectl-isle

--- a/.github/workflows/release-config.yaml
+++ b/.github/workflows/release-config.yaml
@@ -1,0 +1,36 @@
+name: release-config
+
+on:
+  pull_request:
+    paths:
+      - ".goreleaser.yaml"
+      - ".github/workflows/goreleaser.yaml"
+      - ".github/workflows/release-config.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-config-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          distribution: goreleaser
+          version: v2.17.0
+          install-only: true
+
+      - name: Validate release configuration
+        env:
+          GORELEASER_DISABLE_SCM_RELEASE: "false"
+        run: goreleaser check

--- a/.github/workflows/release-config.yaml
+++ b/.github/workflows/release-config.yaml
@@ -31,6 +31,35 @@ jobs:
           install-only: true
 
       - name: Validate release configuration
+        shell: bash
         env:
           GORELEASER_DISABLE_SCM_RELEASE: "false"
-        run: goreleaser check
+        run: |
+          set -euo pipefail
+
+          set +e
+          output="$(goreleaser check 2>&1)"
+          status=$?
+          set -e
+
+          printf '%s\n' "$output"
+
+          if [[ "$status" -eq 0 ]]; then
+            exit 0
+          fi
+
+          if [[ "$status" -ne 2 ]]; then
+            exit "$status"
+          fi
+
+          plain_output="$(printf '%s\n' "$output" | sed $'s/\033\\[[0-9;]*m//g')"
+          if ! grep -Fq "configuration is valid, but uses deprecated properties" <<<"$plain_output"; then
+            echo "GoReleaser did not report a valid deprecated configuration" >&2
+            exit 1
+          fi
+
+          mapfile -t deprecations < <(grep -F "DEPRECATED:" <<<"$plain_output" || true)
+          if [[ "${#deprecations[@]}" -ne 1 ]] || [[ "${deprecations[0]}" != *brews* ]]; then
+            echo "Only the reviewed brews deprecation is allowed" >&2
+            exit 1
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
@@ -29,11 +29,11 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -77,7 +77,7 @@ nfpms:
       - deb
       - rpm
     mtime: "{{ .CommitDate }}"
-    builds:
+    ids:
       - sitectl-isle
     dependencies:
       - sitectl

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,6 @@
 version: 2
+release:
+  disable: "{{ .Env.GORELEASER_DISABLE_SCM_RELEASE }}"
 before:
   hooks:
     - ./scripts/check-sitectl-core-version.sh v0.40.0
@@ -41,14 +43,23 @@ changelog:
       - "^.github"
 brews:
   - name: sitectl-isle
+    description: "A sitectl plugin for Islandora stacks"
     homepage: "https://github.com/libops/sitectl-isle"
+    license: MIT
     commit_author:
       name: sitectl-dev[bot]
       email: 2408410+sitectl-dev[bot]@users.noreply.github.com
     repository:
       owner: libops
       name: homebrew
+      branch: "{{ .ProjectName }}-{{ .Version }}"
       token: "{{ .Env.HOMEBREW_REPO_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: libops
+          name: homebrew
+          branch: main
     dependencies:
       - name: "libops/homebrew/sitectl"
       - name: "libops/homebrew/sitectl-drupal"


### PR DESCRIPTION
## Summary
- publish Homebrew formulas through per-version pull requests instead of racing direct main writes
- add full, Homebrew-only, and package-only recovery modes without replacing existing release assets
- pin Go 1.26.5 and the isolated shared release workflow
- validate GoReleaser configuration on every release-config PR

## Validation
- actionlint v1.7.12
- git diff --check
- GitHub-hosted GoReleaser v2.17.0 configuration check