### PR TITLE
[skip-release] Pin trusted recovery workflow

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   goreleaser:
-    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@66905c983e1ec673e936a7dc4b4d5c2ad0016b49 # main
+    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@ad2e8856581c741cfd811f4704e3674e4c2d6868 # main
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Advance the shared plugin release workflow to the exact revision that keeps recovery source on the release tag, loads publication policy from the default-branch caller SHA, and prevents duplicate SCM release publication.