### PR TITLE
[skip-release] Make Homebrew recovery source explicit

### DIFF
--- a/.github/workflows/release-config.yaml
+++ b/.github/workflows/release-config.yaml
@@ -63,3 +63,16 @@ jobs:
             echo "Only the reviewed brews deprecation is allowed" >&2
             exit 1
           fi
+
+      - name: Verify recovery-safe Homebrew source URL
+        shell: bash
+        env:
+          EXPECTED_BREW_URL: '    url_template: "https://github.com/${{ github.repository }}/releases/download/{{ .Tag }}/{{ .ArtifactName }}"'
+        run: |
+          set -euo pipefail
+
+          matches="$(grep -Fxc "$EXPECTED_BREW_URL" .goreleaser.yaml || true)"
+          if [[ "$matches" -ne 1 ]]; then
+            echo "Expected exactly one recovery-safe Homebrew url_template" >&2
+            exit 1
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,7 @@ brews:
   - name: sitectl-isle
     description: "A sitectl plugin for Islandora stacks"
     homepage: "https://github.com/libops/sitectl-isle"
+    url_template: "https://github.com/libops/sitectl-isle/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     license: MIT
     commit_author:
       name: sitectl-dev[bot]


### PR DESCRIPTION
Adds an explicit GitHub release-asset URL for Homebrew formulas so homebrew-only recovery can keep SCM release publication disabled. CI now requires exactly one repository-bound URL, preventing this recovery path from regressing.