### PR TITLE
[skip-release] Make tag publication deterministic

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   goreleaser:
-    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@ad2e8856581c741cfd811f4704e3674e4c2d6868 # main
+    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3 # main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -33,6 +33,9 @@ jobs:
     secrets: inherit
     with:
       go-version: "1.26.5"
-      release-mode: ${{ inputs.release-mode || 'full' }}
+      # The release bumper dispatches this workflow at the new tag without
+      # inputs. Force every tag ref through the full release path instead of
+      # inheriting the manual recovery default.
+      release-mode: ${{ github.ref_type == 'tag' && 'full' || inputs.release-mode }}
       release-version: ${{ inputs.release-version }}
       package-name: sitectl-isle

--- a/.github/workflows/release-config.yaml
+++ b/.github/workflows/release-config.yaml
@@ -76,3 +76,14 @@ jobs:
             echo "Expected exactly one recovery-safe Homebrew url_template" >&2
             exit 1
           fi
+
+      - name: Verify tag dispatch selects a full release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          matches="$(grep -Fc "github.ref_type == 'tag' && 'full' || inputs.release-mode" .github/workflows/goreleaser.yaml || true)"
+          if [[ "$matches" -ne 1 ]]; then
+            echo "Every tag dispatch must select the full release path" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Forces no-input tag dispatches from the release bumper onto the full release path while preserving explicit default-branch recovery modes. Adds a caller contract check so future workflow updates cannot silently reintroduce the packaging failure observed for v1.0.0.