### PR TITLE
[skip-release] Advance package recovery workflow

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   goreleaser:
-    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3 # main
+    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@77724fe807ede3e0808d4556f47e4ad0ae266bac # main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-config.yaml
+++ b/.github/workflows/release-config.yaml
@@ -87,3 +87,16 @@ jobs:
             echo "Every tag dispatch must select the full release path" >&2
             exit 1
           fi
+
+      - name: Verify trusted package publisher workflow
+        shell: bash
+        env:
+          EXPECTED_WORKFLOW: "libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@77724fe807ede3e0808d4556f47e4ad0ae266bac"
+        run: |
+          set -euo pipefail
+
+          matches="$(grep -Fc "uses: ${EXPECTED_WORKFLOW} # main" .github/workflows/goreleaser.yaml || true)"
+          if [[ "$matches" -ne 1 ]]; then
+            echo "Release publication must use the reviewed shared workflow commit" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Moves the v1 recovery caller to the reviewed shared workflow whose pinned package publisher authorizes sitectl-isle, and adds an exact-SHA release contract. The WIF source allowlist was merged first.\n\nLocal validation: actionlint, exact workflow contract, go test ./..., git diff --check.