### PR TITLE
Fix secret reference in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       id-token: write
     secrets:
-      HOMEBREW_REPO: ${{ secrets.HOMEBREW_REPO }}
+      GITHUB_TOKEN: ${{ secrets.HOMEBREW_REPO }}
     with:
       go-version: "1.26.5"
       # The release bumper dispatches this workflow at the new tag without


### PR DESCRIPTION
Corrected the secret reference for HOMEBREW_REPO to GITHUB_TOKEN.