### PR TITLE
[minor] Use checked-in ISLE lifecycle programs

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,10 +41,9 @@ jobs:
       plugin: isle
       create-definition: default
       images: alpaca=islandora/alpaca:6.3.19@sha256:b7d61c14715376b78c0c01647fef2dc4597c3482e94006e9ab6080e963ca5c61
-      # Frozen at c64d28d8384179d51a49b60c67185c9909db76bf until the template publishes v1.3.0.
       create-args: >-
         --template-repo https://github.com/libops/isle
-        --template-branch checked-in-program-contracts
+        --template-branch v1.3.0
         --fcrepo ${{ matrix.fcrepo_state }}
         --blazegraph ${{ matrix.blazegraph_state }}
         --isle-file-system-uri ${{ matrix.isle_file_system_uri }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,9 +41,10 @@ jobs:
       plugin: isle
       create-definition: default
       images: alpaca=islandora/alpaca:6.3.19@sha256:b7d61c14715376b78c0c01647fef2dc4597c3482e94006e9ab6080e963ca5c61
+      # Frozen at 64406d3637f2f1724ccb4953a8dc623f975984e6 until the template publishes v1.3.0.
       create-args: >-
         --template-repo https://github.com/libops/isle
-        --template-branch v1.2.0
+        --template-branch checked-in-program-contracts
         --fcrepo ${{ matrix.fcrepo_state }}
         --blazegraph ${{ matrix.blazegraph_state }}
         --isle-file-system-uri ${{ matrix.isle_file_system_uri }}
@@ -70,4 +71,5 @@ jobs:
       packages: sitectl sitectl-drupal
       package-versions: sitectl=1.8.1 sitectl-drupal=1.3.0
       allow-unversioned-packages: false
+      expected-template-lock-revision: v1.0.0
       timeout-minutes: 120

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,7 +41,7 @@ jobs:
       plugin: isle
       create-definition: default
       images: alpaca=islandora/alpaca:6.3.19@sha256:b7d61c14715376b78c0c01647fef2dc4597c3482e94006e9ab6080e963ca5c61
-      # Frozen at 64406d3637f2f1724ccb4953a8dc623f975984e6 until the template publishes v1.3.0.
+      # Frozen at c64d28d8384179d51a49b60c67185c9909db76bf until the template publishes v1.3.0.
       create-args: >-
         --template-repo https://github.com/libops/isle
         --template-branch checked-in-program-contracts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sitectl-isle
 
-`sitectl-isle` simplifies the creation and operation of repositories created using the [Islandora ISLE site template](https://github.com/islandora-devops/isle-site-template). It uses sitectl components to make features like Traefik bot mitigation, Triplet IIIF, and Islandora filesystem storage easy to enable and customize.
+`sitectl-isle` simplifies the creation and operation of repositories created using the [LibOps ISLE site template](https://github.com/libops/isle). It uses sitectl components to make features like Traefik bot mitigation, Triplet IIIF, and Islandora filesystem storage easy to enable and customize.
 
 Documentation: https://sitectl.libops.io/plugins/isle
 
@@ -16,14 +16,15 @@ Create a local ISLE site from the matching template:
 
 ```bash
 sitectl create isle/default \
-  --template-repo https://github.com/islandora-devops/isle-site-template \
+  --template-repo https://github.com/libops/isle \
+  --template-branch v1.3.0 \
   --path ./my-isle-site \
   --type local \
   --checkout-source template \
   --default-context
 ```
 
-The template README is at https://github.com/islandora-devops/isle-site-template.
+The template README is at https://github.com/libops/isle.
 
 ## Basic Operations
 
@@ -32,6 +33,8 @@ Use [`sitectl compose`](https://sitectl.libops.io/commands/compose) to start or 
 ```bash
 sitectl compose up --remove-orphans -d
 ```
+
+Before deploying a site created from an older template, update its checkout to the LibOps ISLE v1.3.0 template contract. The checkout must contain `scripts/sitectl-rollout-preflight.sh`, `scripts/drupal-media-storage-state.php`, and `scripts/drupal-wait-installed.sh`. The Drupal service must mount the latter two programs read-only at `/var/www/drupal/drupal-media-storage-state.php` and `/usr/local/lib/sitectl/drupal-wait-installed.sh`, respectively. The preflight also validates the template's Compose file, root CA, Triplet configuration, JWT-key generator, and initializer. `sitectl deploy` executes that complete checked-in preflight and verifies the program sources and effective Compose configuration before stopping services. The direct rollout repeats the preflight after its build preparation and before recreating Drupal.
 
 Use [`sitectl healthcheck`](https://sitectl.libops.io/commands/healthcheck) and [`sitectl validate`](https://sitectl.libops.io/commands/validate) to check the site:
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,21 +39,22 @@ var (
 	createEnsureJWTKeyPair   = createpkg.EnsureJWTKeyPair
 	createApply              = createpkg.Apply
 	createRunProjectCommand  = defaultRunProjectCommand
-	createBootstrapCheckout  = bootstrapCheckout
-	createRunStartup         = runStartup
-	createRewriteCommand     = rewriteCreateProjectShellCommand
-	createRefreshContext     = refreshCreateContextComposeMetadata
-	createPrepareStartup     = prepareCreateStartup
-	createCheckPrereqs       = checkPrereqs
-	createLookPath           = exec.LookPath
-	createRunCheckCommand    = runCheckCommand
-	createSleep              = time.Sleep
-	createComponentBindErr   error
+	createRunComposeCommand  = func(runCtx context.Context, ctx *config.Context, projectDir string, stdout, stderr io.Writer, command string) error {
+		return commandSDK.RunComposeProjectCommandContext(runCtx, ctx, projectDir, stdout, stderr, command)
+	}
+	createBootstrapCheckout = bootstrapCheckout
+	createRunStartup        = runStartup
+	createRefreshContext    = refreshCreateContextComposeMetadata
+	createCheckPrereqs      = checkPrereqs
+	createLookPath          = exec.LookPath
+	createRunCheckCommand   = runCheckCommand
+	createSleep             = time.Sleep
+	createComponentBindErr  error
 )
 
 const (
-	defaultTemplateRepo   = "https://github.com/islandora-devops/isle-site-template"
-	defaultTemplateBranch = "main"
+	defaultTemplateRepo   = "https://github.com/libops/isle"
+	defaultTemplateBranch = "v1.3.0"
 )
 
 type createRequest struct {
@@ -92,7 +92,7 @@ func (createRunner) Run(cmd *cobra.Command) error {
 func createDefinition() plugin.CreateSpec {
 	return plugin.CreateSpec{
 		Name:                "default",
-		Description:         "Create a new ISLE site from the Islandora site template",
+		Description:         "Create a new ISLE site from the LibOps ISLE template",
 		Default:             true,
 		MinCPUCores:         4,
 		MinMemory:           "8 GiB",
@@ -100,7 +100,7 @@ func createDefinition() plugin.CreateSpec {
 		DockerComposeRepo:   defaultTemplateRepo,
 		DockerComposeBranch: defaultTemplateBranch,
 		DockerComposeBuild: []string{
-			"if [ -d drupal/rootfs ]; then find drupal/rootfs -type d -exec chmod 755 {} \\; ; fi",
+			"bash scripts/sitectl-prepare-build.sh",
 			"docker compose pull --ignore-buildable --ignore-pull-failures",
 			"docker compose build",
 		},
@@ -108,9 +108,9 @@ func createDefinition() plugin.CreateSpec {
 			{Service: "drupal", Image: createpkg.DefaultDrupalBaseImageRef, BuildPolicy: plugin.BuildPolicyAlways},
 		},
 		DockerComposeInit: []string{
-			"if [ ! -f .env ]; then cp sample.env .env; fi; if ! grep -q '^DRUPAL_HEALTHCHECK_START_PERIOD=' .env; then printf '\\nDRUPAL_HEALTHCHECK_START_PERIOD=5m\\n' >> .env; fi",
-			"mkdir -p ./certs ./secrets",
-			"attempt=1; until docker compose run --rm -e HOST_UID=\"$(id -u)\" -e HOST_GID=\"$(id -g)\" init; do if [ \"$attempt\" -ge 3 ]; then exit 1; fi; attempt=$((attempt + 1)); sleep 5; done",
+			"bash scripts/sitectl-prepare-init.sh",
+			`docker compose run --rm -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" init`,
+			"bash scripts/sitectl-rollout-preflight.sh",
 		},
 		InitArtifacts: []plugin.InitArtifact{
 			{Path: "certs/cert.pem"},
@@ -135,8 +135,11 @@ func createDefinition() plugin.CreateSpec {
 		DockerComposeRollout: []string{
 			"docker compose pull --ignore-buildable --quiet || docker compose pull --ignore-buildable",
 			"docker compose build --pull",
-			"docker compose up --remove-orphans --pull missing --quiet-pull -d drupal",
-			"docker compose exec -T drupal sh -c 'attempt=0; until test -f /installed; do attempt=$((attempt + 1)); if [ \"$attempt\" -ge 150 ]; then echo \"Drupal did not become ready for database migration within 5 minutes\" >&2; exit 1; fi; sleep 2; done'",
+			"bash scripts/sitectl-rollout-preflight.sh",
+			rolloutComposeConfigCommand,
+			rolloutMountedWaitProbeCommand,
+			"docker compose up --remove-orphans --pull missing --quiet-pull --force-recreate -d drupal",
+			"docker compose exec -T drupal sh /usr/local/lib/sitectl/drupal-wait-installed.sh",
 			"docker compose exec -T --workdir /var/www/drupal drupal drush updb -y",
 			"docker compose exec -T --workdir /var/www/drupal drupal drush cr",
 			"docker compose up --remove-orphans --wait --wait-timeout 600 --pull missing --quiet-pull -d",
@@ -406,9 +409,41 @@ func normalizeComposeProjectFilename(ctx *config.Context) error {
 		return fmt.Errorf("context is nil")
 	}
 	if ctx.DockerHostType == config.ContextRemote {
-		command := "if [ ! -e compose.yaml ] && [ -f docker-compose.yml ]; then mv docker-compose.yml compose.yaml && sed -i 's#\\./docker-compose\\.yml:/docker-compose\\.yml#./compose.yaml:/docker-compose.yml#g' compose.yaml; fi"
-		if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, ctx.ProjectDir, io.Discard, io.Discard, command); err != nil {
+		canonical := filepath.Join(ctx.ProjectDir, "compose.yaml")
+		canonicalExists, err := ctx.FileExists(canonical)
+		if err != nil {
+			return fmt.Errorf("inspect canonical Compose file: %w", err)
+		}
+		if canonicalExists {
+			return nil
+		}
+		legacy := filepath.Join(ctx.ProjectDir, "docker-compose.yml")
+		legacyExists, err := ctx.FileExists(legacy)
+		if err != nil {
+			return fmt.Errorf("inspect legacy Compose file: %w", err)
+		}
+		if !legacyExists {
+			return nil
+		}
+		if err := createRunComposeCommand(
+			context.Background(),
+			ctx,
+			ctx.ProjectDir,
+			io.Discard,
+			io.Discard,
+			plugin.ShellJoin([]string{"mv", "--", "docker-compose.yml", "compose.yaml"}),
+		); err != nil {
 			return fmt.Errorf("normalize Compose project filename: %w", err)
+		}
+		if err := createRunComposeCommand(
+			context.Background(),
+			ctx,
+			ctx.ProjectDir,
+			io.Discard,
+			io.Discard,
+			plugin.ShellJoin([]string{"sed", "-i", `s#\./docker-compose\.yml:/docker-compose\.yml#./compose.yaml:/docker-compose.yml#g`, "compose.yaml"}),
+		); err != nil {
+			return fmt.Errorf("update canonical Compose self-mount: %w", err)
 		}
 		return nil
 	}
@@ -580,19 +615,12 @@ This will completely stop and destroy the setup.`, shellPath(ctx.ProjectDir), cl
 	))
 	fmt.Fprintln(out)
 
-	startupEnv, err := createPrepareStartup(out, ctx)
-	if err != nil {
-		return err
-	}
-
 	if err := runWithSpinner(out, "Starting the Islandora stack", func() error {
 		for _, commandText := range startupCommands() {
 			commandText = strings.TrimSpace(commandText)
 			if commandText == "" {
 				continue
 			}
-			commandText = createRewriteCommand(ctx, commandText)
-			commandText = shellEnvPrefix(startupEnv) + commandText
 			if _, err := fmt.Fprintf(logFile, "Running %s\n", commandText); err != nil {
 				return err
 			}
@@ -622,20 +650,6 @@ This will completely stop and destroy the setup.`, shellPath(ctx.ProjectDir), cl
 	))
 	fmt.Fprintln(out)
 	return nil
-}
-
-func prepareCreateStartup(out io.Writer, ctx *config.Context) (map[string]string, error) {
-	if ctx == nil {
-		return nil, nil
-	}
-	envValues, messages, err := ctx.PrepareComposeUpPortOverride()
-	if err != nil {
-		return nil, err
-	}
-	for _, message := range messages {
-		fmt.Fprintln(out, message)
-	}
-	return envValues, nil
 }
 
 type prereqCheck struct {
@@ -756,47 +770,7 @@ func ensureClonedCheckoutForContext(out io.Writer, ctx *config.Context, req crea
 	if ctx == nil || ctx.DockerHostType != config.ContextRemote {
 		return ensureClonedCheckout(out, req)
 	}
-	repoURL := strings.TrimSpace(req.TemplateRepo)
-	branch := strings.TrimSpace(req.TemplateBranch)
-	projectDir := strings.TrimSpace(ctx.ProjectDir)
-	if repoURL == "" {
-		return false, fmt.Errorf("template repo cannot be empty")
-	}
-	if projectDir == "" {
-		return false, fmt.Errorf("project directory cannot be empty")
-	}
-
-	var present bytes.Buffer
-	checkCommand := fmt.Sprintf("if [ -d %s ] && [ -n \"$(ls -A %s 2>/dev/null)\" ]; then echo present; fi", plugin.ShellQuote(projectDir), plugin.ShellQuote(projectDir))
-	if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, "", &present, io.Discard, checkCommand); err == nil && strings.TrimSpace(present.String()) == "present" {
-		return false, nil
-	}
-	if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, "", io.Discard, io.Discard, fmt.Sprintf("mkdir -p %s", plugin.ShellQuote(filepath.Dir(projectDir)))); err != nil {
-		return false, fmt.Errorf("create parent directory for %q: %w", projectDir, err)
-	}
-
-	fmt.Fprintln(out, corecomponent.RenderSection(
-		"Template checkout",
-		fmt.Sprintf("Cloning %s at %s into %s on %s.", repoURL, helpers.FirstNonEmpty(branch, "default branch"), projectDir, ctx.SSHHostname),
-	))
-	fmt.Fprintln(out)
-	cloneArgs := []string{"git", "clone"}
-	if branch != "" {
-		cloneArgs = append(cloneArgs, "--branch", branch)
-	}
-	cloneArgs = append(cloneArgs, repoURL, projectDir)
-	initBranch := helpers.FirstNonEmpty(branch, "main")
-	cloneCommand := strings.Join([]string{
-		plugin.ShellJoin(cloneArgs),
-		"rm -rf " + plugin.ShellQuote(filepath.Join(projectDir, ".git")),
-		plugin.ShellJoin([]string{"git", "-C", projectDir, "init", "-b", initBranch}),
-	}, " && ")
-	if err := runWithSpinner(out, "Cloning template repository", func() error {
-		return commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, "", io.Discard, io.Discard, cloneCommand)
-	}); err != nil {
-		return false, err
-	}
-	return true, nil
+	return commandSDK.EnsureComposeTemplateCheckoutContext(context.Background(), out, req.ComposeCreateRequest, ctx)
 }
 
 func bootstrapCheckoutForContext(out io.Writer, ctx *config.Context) error {
@@ -812,10 +786,10 @@ func bootstrapCheckoutForContext(out io.Writer, ctx *config.Context) error {
 	fmt.Fprintln(out)
 	return runWithSpinner(out, "Creating initial git commit", func() error {
 		safeDirectory := "safe.directory=" + projectDir
-		if err := commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, projectDir, io.Discard, io.Discard, plugin.ShellJoin([]string{"git", "-c", safeDirectory, "add", "."})); err != nil {
+		if err := createRunComposeCommand(context.Background(), ctx, projectDir, io.Discard, io.Discard, plugin.ShellJoin([]string{"git", "-c", safeDirectory, "add", "."})); err != nil {
 			return fmt.Errorf("stage initial checkout: %w", err)
 		}
-		if err := commandSDK.RunComposeProjectCommandContext(
+		if err := createRunComposeCommand(
 			context.Background(),
 			ctx,
 			projectDir,
@@ -837,17 +811,14 @@ func bootstrapCheckoutForContext(out io.Writer, ctx *config.Context) error {
 }
 
 func runCreateProjectShellCommand(ctx *config.Context, stdout, stderr io.Writer, commandText string) error {
-	if ctx != nil && ctx.DockerHostType == config.ContextRemote {
-		return commandSDK.RunComposeProjectCommandContext(context.Background(), ctx, ctx.ProjectDir, stdout, stderr, commandText)
-	}
-	return createRunProjectCommand(ctx.ProjectDir, stdout, stderr, "bash", "-lc", commandText)
-}
-
-func rewriteCreateProjectShellCommand(ctx *config.Context, commandText string) string {
 	if ctx == nil {
-		return commandText
+		return fmt.Errorf("context is nil")
 	}
-	return ctx.DockerComposeShellCommand(commandText)
+	// The sitectl SDK owns local and remote shell transport. Its only
+	// context-aware project runner currently accepts shell text, invokes
+	// `bash -lc` locally, and has no argv variant. It also applies the local
+	// Compose port environment only to `docker compose up` operations.
+	return createRunComposeCommand(context.Background(), ctx, ctx.ProjectDir, stdout, stderr, commandText)
 }
 
 func bootstrapCheckout(out io.Writer, projectDir string) error {
@@ -898,10 +869,6 @@ func runCheckCommand(name string, args ...string) error {
 	command.Stderr = io.Discard
 	command.Env = os.Environ()
 	return command.Run()
-}
-
-func startupCommand() (string, string, []string) {
-	return "ISLE startup commands", "bash", []string{"-lc", strings.Join(startupCommands(), " && ")}
 }
 
 func startupCommands() []string {
@@ -1159,25 +1126,4 @@ func shellSingleQuote(value string) string {
 
 func shellPath(value string) string {
 	return shellSingleQuote(value)
-}
-
-func shellEnvPrefix(values map[string]string) string {
-	if len(values) == 0 {
-		return ""
-	}
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		if strings.TrimSpace(key) != "" {
-			keys = append(keys, key)
-		}
-	}
-	sort.Strings(keys)
-	parts := make([]string, 0, len(keys))
-	for _, key := range keys {
-		parts = append(parts, key+"="+shellSingleQuote(values[key]))
-	}
-	if len(parts) == 0 {
-		return ""
-	}
-	return "export " + strings.Join(parts, " ") + "; "
 }

--- a/cmd/create_contract_test.go
+++ b/cmd/create_contract_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -8,17 +9,45 @@ import (
 	"github.com/libops/sitectl/pkg/plugin"
 )
 
-func TestCreateDefinitionUsesTemplateInitContract(t *testing.T) {
+func TestCreateRuntimeDoesNotEmbedNontrivialLifecycleShellPrograms(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("create.go")
+	if err != nil {
+		t.Fatalf("ReadFile(create.go) error = %v", err)
+	}
+	source := string(data)
+	if !strings.Contains(source, "EnsureComposeTemplateCheckoutContext") {
+		t.Fatal("remote template checkout must delegate to the sitectl SDK")
+	}
+	for _, forbidden := range []string{
+		`"bash", "-lc"`,
+		"shellEnvPrefix(",
+		"func startupCommand()",
+		"attempt=1; until docker compose",
+		"if [ ! -f .env ]",
+		"until test -f /installed",
+		"mv docker-compose.yml compose.yaml && sed",
+		"if [ -d %s ] && [ -n",
+		"cloneCommand := strings.Join",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("create runtime must delegate checked-in programs instead of containing %q", forbidden)
+		}
+	}
+}
+
+func TestCreateDefinitionUsesCheckedInTemplatePrograms(t *testing.T) {
 	t.Parallel()
 	spec := createDefinition()
-	if len(spec.DockerComposeInit) != 3 || !strings.Contains(spec.DockerComposeInit[0], "cp sample.env .env") || !strings.Contains(spec.DockerComposeInit[2], "docker compose run --rm") || !strings.Contains(spec.DockerComposeInit[2], "HOST_UID") {
-		t.Fatalf("create init must use the shared Compose init service: %+v", spec.DockerComposeInit)
+	if spec.DockerComposeRepo != "https://github.com/libops/isle" || spec.DockerComposeBranch != "v1.3.0" {
+		t.Fatalf("unexpected template contract: repo=%q branch=%q", spec.DockerComposeRepo, spec.DockerComposeBranch)
 	}
-	if !strings.Contains(spec.DockerComposeInit[0], "DRUPAL_HEALTHCHECK_START_PERIOD=5m") {
-		t.Fatalf("create must allow enough startup time for development dependency installation: %+v", spec.DockerComposeInit)
+	if len(spec.DockerComposeInit) != 3 || spec.DockerComposeInit[0] != "bash scripts/sitectl-prepare-init.sh" || spec.DockerComposeInit[1] != `docker compose run --rm -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" init` || spec.DockerComposeInit[2] != "bash scripts/sitectl-rollout-preflight.sh" {
+		t.Fatalf("create init must separate checked-in preparation from the context-aware Compose command: %+v", spec.DockerComposeInit)
 	}
-	if !strings.Contains(spec.DockerComposeInit[2], `"$attempt" -ge 3`) {
-		t.Fatalf("create must tolerate transient certificate-tool download failures: %+v", spec.DockerComposeInit)
+	if len(spec.DockerComposeBuild) != 3 || spec.DockerComposeBuild[0] != "bash scripts/sitectl-prepare-build.sh" || spec.DockerComposeBuild[1] != "docker compose pull --ignore-buildable --ignore-pull-failures" || spec.DockerComposeBuild[2] != "docker compose build" {
+		t.Fatalf("create build must separate checked-in preparation from context-aware Compose commands: %+v", spec.DockerComposeBuild)
 	}
 	if len(spec.Images) != 1 || spec.Images[0].Service != "drupal" || spec.Images[0].Image != createpkg.DefaultDrupalBaseImageRef || spec.Images[0].BuildPolicy != plugin.BuildPolicyAlways {
 		t.Fatalf("the derived ISLE application image must always rebuild: %+v", spec.Images)
@@ -37,16 +66,25 @@ func TestCreateDefinitionUsesTemplateInitContract(t *testing.T) {
 	if !strings.Contains(rollout, "docker compose build --pull") || strings.Contains(rollout, "|| true") {
 		t.Fatalf("rollout must rebuild and propagate failures:\n%s", rollout)
 	}
+	if !strings.Contains(rollout, "sh /usr/local/lib/sitectl/drupal-wait-installed.sh") || strings.Contains(rollout, "until test -f /installed") {
+		t.Fatalf("rollout must invoke the mounted Drupal readiness program:\n%s", rollout)
+	}
+	if !strings.Contains(rollout, "bash scripts/sitectl-rollout-preflight.sh") {
+		t.Fatalf("rollout must fail safely on incompatible template checkouts:\n%s", rollout)
+	}
+	if !strings.Contains(rollout, "docker compose config --quiet") || !strings.Contains(rollout, "docker compose run --rm --no-deps --entrypoint test drupal -r "+rolloutWaitScriptTarget) {
+		t.Fatalf("rollout must validate the effective context-aware Compose mount:\n%s", rollout)
+	}
 }
 
 func TestCreateDefinitionRolloutRunsBoundedDrupalMigrations(t *testing.T) {
 	t.Parallel()
 
 	rollout := createDefinition().DockerComposeRollout
-	if len(rollout) != 7 {
-		t.Fatalf("rollout commands = %d, want 7: %+v", len(rollout), rollout)
+	if len(rollout) != 10 {
+		t.Fatalf("rollout commands = %d, want 10: %+v", len(rollout), rollout)
 	}
-	for _, index := range []int{6} {
+	for _, index := range []int{9} {
 		command := rollout[index]
 		if !strings.Contains(command, "docker compose up") || !strings.Contains(command, "--wait --wait-timeout 600") || !strings.Contains(command, "-d") {
 			t.Fatalf("rollout command %d must use a bounded detached health wait: %q", index, command)
@@ -55,20 +93,23 @@ func TestCreateDefinitionRolloutRunsBoundedDrupalMigrations(t *testing.T) {
 	for index, want := range map[int]string{
 		0: "docker compose pull",
 		1: "docker compose build --pull",
-		2: "docker compose up",
-		3: "until test -f /installed",
-		4: "docker compose exec -T --workdir /var/www/drupal drupal drush updb -y",
-		5: "docker compose exec -T --workdir /var/www/drupal drupal drush cr",
-		6: "docker compose up",
+		2: "bash scripts/sitectl-rollout-preflight.sh",
+		3: "docker compose config --quiet",
+		4: "docker compose run --rm --no-deps --entrypoint test drupal -r /usr/local/lib/sitectl/drupal-wait-installed.sh",
+		5: "docker compose up",
+		6: "docker compose exec -T drupal sh /usr/local/lib/sitectl/drupal-wait-installed.sh",
+		7: "docker compose exec -T --workdir /var/www/drupal drupal drush updb -y",
+		8: "docker compose exec -T --workdir /var/www/drupal drupal drush cr",
+		9: "docker compose up",
 	} {
 		if !strings.Contains(rollout[index], want) {
 			t.Fatalf("rollout command %d = %q, want %q in order", index, rollout[index], want)
 		}
 	}
-	if !strings.HasSuffix(rollout[2], " -d drupal") || strings.Contains(rollout[2], "--wait") {
-		t.Fatalf("initial migration start must target Drupal without exposing the full stack: %q", rollout[2])
+	if !strings.HasSuffix(rollout[5], " -d drupal") || strings.Contains(rollout[5], "--wait") || !strings.Contains(rollout[5], "--force-recreate") {
+		t.Fatalf("initial migration start must target Drupal without exposing the full stack: %q", rollout[5])
 	}
-	for _, index := range []int{4, 5} {
+	for _, index := range []int{7, 8} {
 		if strings.Contains(rollout[index], "||") {
 			t.Fatalf("Drupal migration command %d must fail hard: %q", index, rollout[index])
 		}

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -459,28 +460,6 @@ func TestCheckPrereqsFailsEarly(t *testing.T) {
 	rendered := stripANSI(out.String())
 	if !strings.Contains(rendered, "• git is installed: failed") {
 		t.Fatalf("expected failed checklist line, got:\n%s", rendered)
-	}
-}
-
-func TestStartupCommandUsesCreateDefinitionLifecycle(t *testing.T) {
-	label, name, args := startupCommand()
-	if label != "ISLE startup commands" {
-		t.Fatalf("expected ISLE startup label, got %q", label)
-	}
-	if name != "bash" {
-		t.Fatalf("expected bash command, got %q", name)
-	}
-	if len(args) != 2 || args[0] != "-lc" {
-		t.Fatalf("expected bash lifecycle args, got %#v", args)
-	}
-	for _, want := range []string{
-		"docker compose pull --ignore-buildable",
-		"docker compose build",
-		"docker compose up --remove-orphans --wait --wait-timeout 600 -d",
-	} {
-		if !strings.Contains(args[1], want) {
-			t.Fatalf("expected startup command to contain %q, got %q", want, args[1])
-		}
 	}
 }
 
@@ -986,82 +965,41 @@ func TestBootstrapCheckoutRunsGitAddAndInitialCommit(t *testing.T) {
 	}
 }
 
-func TestRunStartupPreparesLocalPortEnv(t *testing.T) {
+func TestRunStartupDelegatesLifecycleCommandsToComposeSDK(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	projectDir := t.TempDir()
 
-	oldPrepare := createPrepareStartup
-	oldRunProject := createRunProjectCommand
-	oldRewrite := createRewriteCommand
+	oldRunCompose := createRunComposeCommand
 	t.Cleanup(func() {
-		createPrepareStartup = oldPrepare
-		createRunProjectCommand = oldRunProject
-		createRewriteCommand = oldRewrite
+		createRunComposeCommand = oldRunCompose
 	})
 
-	var prepared bool
-	createPrepareStartup = func(out io.Writer, ctx *config.Context) (map[string]string, error) {
-		prepared = true
-		if ctx.ProjectDir != projectDir {
-			t.Fatalf("expected prepare project dir %q, got %q", projectDir, ctx.ProjectDir)
-		}
-		return map[string]string{
-			"SITE_URL":   "http://localhost:8081",
-			"URI_SCHEME": "http",
-		}, nil
-	}
-
 	var commands []string
-	var rewrites []string
-	createRewriteCommand = func(ctx *config.Context, command string) string {
-		if strings.HasPrefix(command, "export ") {
-			t.Fatalf("expected compose rewrite before startup env prefix, got %q", command)
-		}
-		rewrites = append(rewrites, command)
-		return "rewritten(" + command + ")"
-	}
-	createRunProjectCommand = func(gotProjectDir string, stdout, stderr io.Writer, name string, args ...string) error {
+	createRunComposeCommand = func(runCtx context.Context, ctx *config.Context, gotProjectDir string, stdout, stderr io.Writer, command string) error {
 		if gotProjectDir != projectDir {
 			t.Fatalf("expected project dir %q, got %q", projectDir, gotProjectDir)
 		}
-		if name != "bash" || len(args) != 2 || args[0] != "-lc" {
-			t.Fatalf("expected bash -lc command, got %s %v", name, args)
+		if ctx == nil || ctx.Name != "isle-local" {
+			t.Fatalf("unexpected context: %#v", ctx)
 		}
-		commands = append(commands, args[1])
+		commands = append(commands, command)
 		return nil
 	}
 
 	if err := runStartup(io.Discard, &config.Context{Name: "isle-local", ProjectDir: projectDir}); err != nil {
 		t.Fatalf("runStartup() error = %v", err)
 	}
-	if !prepared {
-		t.Fatal("expected startup port preparation")
+	want := startupCommands()
+	if len(commands) != len(want) {
+		t.Fatalf("startup commands = %#v, want %#v", commands, want)
 	}
-	if len(commands) == 0 {
-		t.Fatal("expected startup commands")
-	}
-	if len(rewrites) != len(commands) {
-		t.Fatalf("expected every startup command to be rewritten before execution, got rewrites=%d commands=%d", len(rewrites), len(commands))
-	}
-	for _, command := range commands {
-		if !strings.HasPrefix(command, "export SITE_URL='http://localhost:8081' URI_SCHEME='http'; rewritten(") {
-			t.Fatalf("expected command to include local port env prefix, got %q", command)
+	for index := range want {
+		if commands[index] != want[index] {
+			t.Fatalf("startup command %d = %q, want %q", index, commands[index], want[index])
 		}
-	}
-}
-
-func TestShellEnvPrefixWorksBeforeCompoundCommands(t *testing.T) {
-	got := shellEnvPrefix(map[string]string{
-		"SITE_URL":   "http://localhost:8081",
-		"URI_SCHEME": "http",
-	})
-	want := "export SITE_URL='http://localhost:8081' URI_SCHEME='http'; "
-	if got != want {
-		t.Fatalf("shellEnvPrefix() = %q, want %q", got, want)
-	}
-	compound := got + "if [ -d drupal/rootfs ]; then find drupal/rootfs -type d -exec chmod 755 {} \\; ; fi"
-	if !strings.Contains(compound, "; if [ -d drupal/rootfs ]") {
-		t.Fatalf("expected export prefix to terminate before compound command, got %q", compound)
+		if strings.HasPrefix(commands[index], "export ") {
+			t.Fatalf("startup command %d unexpectedly materialized an environment prefix: %q", index, commands[index])
+		}
 	}
 }
 

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -28,6 +28,10 @@ func TestRegisterCommandsUsesRPCValidationAndCuratedDirectCommands(t *testing.T)
 	if got := len(sdk.ContextValidators()); got != 0 {
 		t.Fatalf("expected no legacy context validators, got %d", got)
 	}
+	deploys := sdk.DeployDefinitions()
+	if len(deploys) != 1 || deploys[0].Name != "default" {
+		t.Fatalf("expected the outage-prevention deploy contract, got %#v", deploys)
+	}
 	for _, name := range []string{"component", "status", "validate"} {
 		if _, _, err := sdk.RootCmd.Find([]string{name}); err == nil {
 			t.Fatalf("did not expect legacy direct command %q to be registered", name)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -41,7 +41,7 @@ func (isleDeployRunner) BindFlags(*cobra.Command) {}
 
 func (isleDeployRunner) PreDown(cmd *cobra.Command, ctx *config.Context) error {
 	runCtx := context.Background()
-	if cmd != nil {
+	if cmd != nil && cmd.Context() != nil {
 		runCtx = cmd.Context()
 	}
 	if err := validateRolloutTemplateContractContext(runCtx, ctx); err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/libops/sitectl/pkg/config"
+	"github.com/libops/sitectl/pkg/plugin"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	rolloutPreflightScript         = "scripts/sitectl-rollout-preflight.sh"
+	rolloutPreflightCommand        = "bash " + rolloutPreflightScript
+	rolloutMediaStateScriptSource  = "scripts/drupal-media-storage-state.php"
+	rolloutMediaStateScriptTarget  = "/var/www/drupal/drupal-media-storage-state.php"
+	rolloutWaitScriptSource        = "scripts/drupal-wait-installed.sh"
+	rolloutWaitScriptTarget        = "/usr/local/lib/sitectl/drupal-wait-installed.sh"
+	rolloutComposeConfigCommand    = "docker compose config --quiet"
+	rolloutMountedWaitProbeCommand = "docker compose run --rm --no-deps --entrypoint test drupal -r " + rolloutWaitScriptTarget
+)
+
+type rolloutBindContract struct {
+	source string
+	target string
+}
+
+var rolloutBindContracts = []rolloutBindContract{
+	{source: rolloutMediaStateScriptSource, target: rolloutMediaStateScriptTarget},
+	{source: rolloutWaitScriptSource, target: rolloutWaitScriptTarget},
+}
+
+type isleDeployRunner struct{}
+
+func (isleDeployRunner) BindFlags(*cobra.Command) {}
+
+func (isleDeployRunner) PreDown(cmd *cobra.Command, ctx *config.Context) error {
+	runCtx := context.Background()
+	if cmd != nil {
+		runCtx = cmd.Context()
+	}
+	if err := validateRolloutTemplateContractContext(runCtx, ctx); err != nil {
+		return err
+	}
+	stdout, stderr := io.Writer(io.Discard), io.Writer(io.Discard)
+	if cmd != nil {
+		stdout = cmd.OutOrStdout()
+		stderr = cmd.ErrOrStderr()
+	}
+	if err := createRunComposeCommand(runCtx, ctx, ctx.ProjectDir, stdout, stderr, rolloutPreflightCommand); err != nil {
+		return rolloutTemplateMigrationError(fmt.Sprintf(
+			"the complete tracked preflight %s rejected one or more required rollout sources: %v",
+			rolloutPreflightScript,
+			err,
+		))
+	}
+	if err := createRunComposeCommand(runCtx, ctx, ctx.ProjectDir, stdout, stderr, rolloutComposeConfigCommand); err != nil {
+		return fmt.Errorf("validate effective ISLE Compose configuration before services were stopped: %w", err)
+	}
+	if err := createRunComposeCommand(runCtx, ctx, ctx.ProjectDir, stdout, stderr, rolloutMountedWaitProbeCommand); err != nil {
+		return rolloutTemplateMigrationError(fmt.Sprintf("the effective drupal service cannot read %s", rolloutWaitScriptTarget))
+	}
+	return nil
+}
+
+func (isleDeployRunner) PostUp(*cobra.Command, *config.Context) error {
+	return nil
+}
+
+func isleDeployDefinition() plugin.DeploySpec {
+	return plugin.DeploySpec{
+		Name:        "default",
+		Description: "Validate the ISLE template contract before replacing running services",
+		Default:     true,
+	}
+}
+
+func validateRolloutTemplateContractContext(runCtx context.Context, ctx *config.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("validate ISLE rollout contract: context is nil")
+	}
+	projectDir := strings.TrimSpace(ctx.ProjectDir)
+	if projectDir == "" {
+		return fmt.Errorf("validate ISLE rollout contract: context %q does not define a project directory", ctx.Name)
+	}
+
+	requiredPrograms := []string{rolloutPreflightScript}
+	for _, contract := range rolloutBindContracts {
+		requiredPrograms = append(requiredPrograms, contract.source)
+	}
+	for _, relativePath := range requiredPrograms {
+		programPath := filepath.Join(projectDir, filepath.FromSlash(relativePath))
+		exists, err := ctx.FileExists(programPath)
+		if err != nil {
+			return fmt.Errorf("inspect ISLE rollout program %q: %w", relativePath, err)
+		}
+		if !exists {
+			return rolloutTemplateMigrationError(fmt.Sprintf("missing tracked %s", relativePath))
+		}
+		for _, probeArgs := range [][]string{{"-f", programPath}, {"!", "-L", programPath}} {
+			if _, err := ctx.RunQuietCommandContext(runCtx, exec.Command("test", probeArgs...)); err != nil { // #nosec G204 -- fixed file-type probes receive context-scoped rollout paths as argv values.
+				return rolloutTemplateMigrationError(fmt.Sprintf("%s must be a regular tracked file, not a directory or symbolic link", relativePath))
+			}
+		}
+	}
+
+	foundComposeFile := false
+	for _, composePath := range rolloutComposePaths(ctx) {
+		exists, err := ctx.FileExists(composePath)
+		if err != nil {
+			return fmt.Errorf("inspect Compose file %q: %w", composePath, err)
+		}
+		if !exists {
+			continue
+		}
+		foundComposeFile = true
+		data, err := ctx.ReadFile(composePath)
+		if err != nil {
+			return fmt.Errorf("read Compose file %q: %w", composePath, err)
+		}
+		matchesAll := true
+		for _, contract := range rolloutBindContracts {
+			matches, err := composeHasReadOnlyBind(data, projectDir, contract)
+			if err != nil {
+				return fmt.Errorf("parse Compose file %q: %w", composePath, err)
+			}
+			if !matches {
+				matchesAll = false
+				break
+			}
+		}
+		if matchesAll {
+			return nil
+		}
+	}
+	if !foundComposeFile {
+		return rolloutTemplateMigrationError("no configured Compose file was found")
+	}
+	return rolloutTemplateMigrationError("the drupal service does not bind every required checked-in rollout program read-only at its template target")
+}
+
+func rolloutComposePaths(ctx *config.Context) []string {
+	candidates := append([]string{}, ctx.ComposeFile...)
+	candidates = append(candidates, "compose.yaml", "docker-compose.yml")
+	paths := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		resolved := candidate
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(ctx.ProjectDir, resolved)
+		}
+		resolved = filepath.Clean(resolved)
+		if _, ok := seen[resolved]; ok {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		paths = append(paths, resolved)
+	}
+	return paths
+}
+
+func composeHasReadOnlyBind(data []byte, projectDir string, contract rolloutBindContract) (bool, error) {
+	var compose struct {
+		Services map[string]struct {
+			Volumes []yaml.Node `yaml:"volumes"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(data, &compose); err != nil {
+		return false, err
+	}
+	drupal, ok := compose.Services["drupal"]
+	if !ok {
+		return false, nil
+	}
+	for _, volume := range drupal.Volumes {
+		if composeVolumeMatchesReadOnlyBind(volume, projectDir, contract) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func composeVolumeMatchesReadOnlyBind(volume yaml.Node, projectDir string, contract rolloutBindContract) bool {
+	if volume.Kind == yaml.AliasNode && volume.Alias != nil {
+		return composeVolumeMatchesReadOnlyBind(*volume.Alias, projectDir, contract)
+	}
+	switch volume.Kind {
+	case yaml.ScalarNode:
+		parts := strings.SplitN(strings.TrimSpace(volume.Value), ":", 3)
+		return len(parts) == 3 && rolloutBindSourceMatches(parts[0], projectDir, contract.source) && filepath.Clean(parts[1]) == contract.target && composeVolumeModeReadOnly(parts[2])
+	case yaml.MappingNode:
+		values := make(map[string]string, len(volume.Content)/2)
+		for index := 0; index+1 < len(volume.Content); index += 2 {
+			values[strings.TrimSpace(volume.Content[index].Value)] = strings.TrimSpace(volume.Content[index+1].Value)
+		}
+		volumeType := values["type"]
+		return (volumeType == "" || volumeType == "bind") && strings.EqualFold(values["read_only"], "true") &&
+			rolloutBindSourceMatches(values["source"], projectDir, contract.source) &&
+			filepath.Clean(values["target"]) == contract.target
+	default:
+		return false
+	}
+}
+
+func composeVolumeModeReadOnly(mode string) bool {
+	for _, option := range strings.Split(mode, ",") {
+		if strings.TrimSpace(option) == "ro" {
+			return true
+		}
+	}
+	return false
+}
+
+func rolloutBindSourceMatches(source, projectDir, expectedSource string) bool {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return false
+	}
+	if !filepath.IsAbs(source) {
+		source = filepath.Join(projectDir, source)
+	}
+	want := filepath.Join(projectDir, filepath.FromSlash(expectedSource))
+	return filepath.Clean(source) == filepath.Clean(want)
+}
+
+func rolloutTemplateMigrationError(detail string) error {
+	return fmt.Errorf(
+		"ISLE rollout compatibility check failed before services were stopped: %s; update the site checkout from %s at %s or newer so its checked-in preflight and read-only Drupal program mounts match the template contract, then rerun sitectl deploy",
+		detail,
+		defaultTemplateRepo,
+		defaultTemplateBranch,
+	)
+}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1,0 +1,272 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/libops/sitectl/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func TestIsleDeployRunnerPreDownChecksEffectiveComposeBeforeOutage(t *testing.T) {
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - ./scripts/drupal-media-storage-state.php:/var/www/drupal/drupal-media-storage-state.php:ro,z
+      - ./scripts/drupal-wait-installed.sh:/usr/local/lib/sitectl/drupal-wait-installed.sh:ro,z
+`)
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+
+	oldRunCompose := createRunComposeCommand
+	t.Cleanup(func() {
+		createRunComposeCommand = oldRunCompose
+	})
+	var commands []string
+	createRunComposeCommand = func(runCtx context.Context, gotCtx *config.Context, gotProjectDir string, stdout, stderr io.Writer, command string) error {
+		if gotCtx != ctx || gotProjectDir != projectDir {
+			t.Fatalf("unexpected rollout context: ctx=%#v project=%q", gotCtx, gotProjectDir)
+		}
+		commands = append(commands, command)
+		return nil
+	}
+
+	cmd := &cobra.Command{Use: "pre-down"}
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := (isleDeployRunner{}).PreDown(cmd, ctx); err != nil {
+		t.Fatalf("PreDown() error = %v", err)
+	}
+	want := []string{rolloutPreflightCommand, rolloutComposeConfigCommand, rolloutMountedWaitProbeCommand}
+	if len(commands) != len(want) {
+		t.Fatalf("effective Compose commands = %#v, want %#v", commands, want)
+	}
+	for index := range want {
+		if commands[index] != want[index] {
+			t.Fatalf("effective Compose command %d = %q, want %q", index, commands[index], want[index])
+		}
+	}
+}
+
+func TestIsleDeployRunnerPreDownStopsWhenCompletePreflightRejectsRequiredSource(t *testing.T) {
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - ./scripts/drupal-media-storage-state.php:/var/www/drupal/drupal-media-storage-state.php:ro,z
+      - ./scripts/drupal-wait-installed.sh:/usr/local/lib/sitectl/drupal-wait-installed.sh:ro,z
+`)
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+
+	oldRunCompose := createRunComposeCommand
+	t.Cleanup(func() {
+		createRunComposeCommand = oldRunCompose
+	})
+	var commands []string
+	createRunComposeCommand = func(_ context.Context, _ *config.Context, _ string, _, _ io.Writer, command string) error {
+		commands = append(commands, command)
+		if command == rolloutPreflightCommand {
+			return errors.New("missing required source certs/rootCA.pem")
+		}
+		return nil
+	}
+
+	err := (isleDeployRunner{}).PreDown(&cobra.Command{Use: "pre-down"}, ctx)
+	assertActionableRolloutContractError(t, err, "complete tracked preflight")
+	if len(commands) != 1 || commands[0] != rolloutPreflightCommand {
+		t.Fatalf("commands after rejected complete preflight = %#v, want only %#v", commands, []string{rolloutPreflightCommand})
+	}
+}
+
+func TestValidateRolloutTemplateContractAcceptsMountedCheckedInPrograms(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - type: bind
+        source: ./scripts/drupal-media-storage-state.php
+        target: /var/www/drupal/drupal-media-storage-state.php
+        read_only: true
+      - type: bind
+        source: ./scripts/drupal-wait-installed.sh
+        target: /usr/local/lib/sitectl/drupal-wait-installed.sh
+        read_only: true
+`)
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	if err := validateRolloutTemplateContractContext(t.Context(), ctx); err != nil {
+		t.Fatalf("validateRolloutTemplateContractContext() error = %v", err)
+	}
+}
+
+func TestValidateRolloutTemplateContractAcceptsShortBindSyntax(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - ./scripts/drupal-media-storage-state.php:/var/www/drupal/drupal-media-storage-state.php:ro,z
+      - ./scripts/drupal-wait-installed.sh:/usr/local/lib/sitectl/drupal-wait-installed.sh:ro,z
+`)
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	if err := validateRolloutTemplateContractContext(t.Context(), ctx); err != nil {
+		t.Fatalf("validateRolloutTemplateContractContext() error = %v", err)
+	}
+}
+
+func TestValidateRolloutTemplateContractRejectsMissingWaitProgramBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, "services:\n  drupal: {}\n")
+	if err := os.Remove(filepath.Join(projectDir, "scripts", "drupal-wait-installed.sh")); err != nil {
+		t.Fatalf("Remove(wait program) error = %v", err)
+	}
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "missing tracked scripts/drupal-wait-installed.sh")
+}
+
+func TestValidateRolloutTemplateContractRejectsMissingPreflightBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, "services:\n  drupal: {}\n")
+	if err := os.Remove(filepath.Join(projectDir, "scripts", "sitectl-rollout-preflight.sh")); err != nil {
+		t.Fatalf("Remove(preflight program) error = %v", err)
+	}
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "missing tracked scripts/sitectl-rollout-preflight.sh")
+}
+
+func TestValidateRolloutTemplateContractRejectsMissingMediaStateProgramBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, "services:\n  drupal: {}\n")
+	if err := os.Remove(filepath.Join(projectDir, "scripts", "drupal-media-storage-state.php")); err != nil {
+		t.Fatalf("Remove(media state program) error = %v", err)
+	}
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "missing tracked scripts/drupal-media-storage-state.php")
+}
+
+func TestValidateRolloutTemplateContractRejectsMissingBindBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, "services:\n  drupal: {}\n")
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "does not bind")
+}
+
+func TestValidateRolloutTemplateContractRejectsWritableBindBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - type: bind
+        source: ./scripts/drupal-media-storage-state.php
+        target: /var/www/drupal/drupal-media-storage-state.php
+        read_only: true
+      - type: bind
+        source: ./scripts/drupal-wait-installed.sh
+        target: /usr/local/lib/sitectl/drupal-wait-installed.sh
+        read_only: false
+`)
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "does not bind")
+}
+
+func TestValidateRolloutTemplateContractRejectsSymlinkedWaitProgramBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - type: bind
+        source: ./scripts/drupal-media-storage-state.php
+        target: /var/www/drupal/drupal-media-storage-state.php
+        read_only: true
+      - type: bind
+        source: ./scripts/drupal-wait-installed.sh
+        target: /usr/local/lib/sitectl/drupal-wait-installed.sh
+        read_only: true
+`)
+	waitProgram := filepath.Join(projectDir, "scripts", "drupal-wait-installed.sh")
+	if err := os.Remove(waitProgram); err != nil {
+		t.Fatalf("Remove(wait program) error = %v", err)
+	}
+	if err := os.Symlink(filepath.Join(projectDir, "compose.yaml"), waitProgram); err != nil {
+		t.Fatalf("Symlink(wait program) error = %v", err)
+	}
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "must be a regular tracked file")
+}
+
+func TestValidateRolloutTemplateContractRejectsSymlinkedMediaStateProgramBeforeOutage(t *testing.T) {
+	t.Parallel()
+
+	projectDir := writeRolloutContractFixture(t, `services:
+  drupal:
+    volumes:
+      - ./scripts/drupal-media-storage-state.php:/var/www/drupal/drupal-media-storage-state.php:ro,z
+      - ./scripts/drupal-wait-installed.sh:/usr/local/lib/sitectl/drupal-wait-installed.sh:ro,z
+`)
+	mediaStateProgram := filepath.Join(projectDir, "scripts", "drupal-media-storage-state.php")
+	if err := os.Remove(mediaStateProgram); err != nil {
+		t.Fatalf("Remove(media state program) error = %v", err)
+	}
+	if err := os.Symlink(filepath.Join(projectDir, "compose.yaml"), mediaStateProgram); err != nil {
+		t.Fatalf("Symlink(media state program) error = %v", err)
+	}
+	ctx := &config.Context{DockerHostType: config.ContextLocal, ProjectDir: projectDir}
+	err := validateRolloutTemplateContractContext(t.Context(), ctx)
+	assertActionableRolloutContractError(t, err, "must be a regular tracked file")
+}
+
+func writeRolloutContractFixture(t *testing.T, compose string) string {
+	t.Helper()
+	projectDir := t.TempDir()
+	scriptsDir := filepath.Join(projectDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(scripts) error = %v", err)
+	}
+	for name, contents := range map[string]string{
+		"drupal-media-storage-state.php": "<?php\n",
+		"drupal-wait-installed.sh":       "#!/bin/sh\n",
+		"sitectl-rollout-preflight.sh":   "#!/usr/bin/env bash\n",
+	} {
+		if err := os.WriteFile(filepath.Join(scriptsDir, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte(compose), 0o644); err != nil {
+		t.Fatalf("WriteFile(compose.yaml) error = %v", err)
+	}
+	return projectDir
+}
+
+func assertActionableRolloutContractError(t *testing.T, err error, detail string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected rollout contract failure")
+	}
+	for _, want := range []string{
+		"before services were stopped",
+		detail,
+		"https://github.com/libops/isle",
+		"v1.3.0",
+		"then rerun sitectl deploy",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ func RegisterCommands(sdk *plugin.SDK) {
 	sdk.RegisterComponentCommand(componentExtensionCmd)
 	sdk.AddCommand(cacheCmd)
 	sdk.RegisterCreateRunner(createDefinition(), createRunner{})
+	sdk.RegisterDeployRunner(isleDeployDefinition(), isleDeployRunner{})
 	sdk.RegisterDebugRunner(&isleDebugRunner{})
 	sdk.RegisterConvergeRunner(&isleConvergeRunner{})
 	sdk.RegisterSetRunner(&isleSetRunner{})

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +27,8 @@ const (
 	verifyExpectedAuto = "auto"
 	verifyIIIFLocal    = "local"
 )
+
+var verifyRunLocalProjectOutput = runLocalProjectOutput
 
 type isleVerifyRunner struct {
 	path              string
@@ -317,7 +318,22 @@ func verifyNoFedoraManagedFiles(ctx context.Context, projectDir string) sitevali
 	if strings.TrimSpace(projectDir) == "" {
 		return warningVerifyResult("verify:fcrepo:file-managed", "skipped because the context does not define a local project directory")
 	}
-	out, err := runLocalProjectOutput(ctx, projectDir, "docker", "compose", "exec", "-T", "drupal", "bash", "-lc", `drush --root=/var/www/drupal sql:query --extra=--skip-column-names "SELECT COUNT(*) FROM file_managed WHERE uri LIKE 'fedora%';"`)
+	out, err := verifyRunLocalProjectOutput(
+		ctx,
+		projectDir,
+		"docker",
+		"compose",
+		"exec",
+		"-T",
+		"--workdir",
+		"/var/www/drupal",
+		"drupal",
+		"drush",
+		"--root=/var/www/drupal",
+		"sql:query",
+		"--extra=--skip-column-names",
+		"SELECT COUNT(*) FROM file_managed WHERE uri LIKE 'fedora%';",
+	)
 	if err != nil {
 		return failedVerifyResult("verify:fcrepo:file-managed", err.Error(), "")
 	}
@@ -360,6 +376,15 @@ func verifyDemoObjects(ctx context.Context, projectDir, fcrepoExpected, fileSyst
 }
 
 func runDemoObjectsScript(ctx context.Context, projectDir string) (string, error) {
+	canonicalPath := filepath.Join(projectDir, "scripts", "demo-objects.sh")
+	data, err := os.ReadFile(canonicalPath) // #nosec G304 -- path is scoped to the selected project.
+	if err != nil {
+		return "", fmt.Errorf("read canonical demo-objects script: %w", err)
+	}
+	if err := validateDemoObjectsScriptContract(data); err != nil {
+		return "", err
+	}
+
 	if err := createpkg.SyncLocalDrupalInternalIngress(projectDir, true); err != nil {
 		return "", fmt.Errorf("reconcile Workbench internal route: %w", err)
 	}
@@ -399,22 +424,7 @@ func runDemoObjectsScript(ctx context.Context, projectDir string) (string, error
 		return "", fmt.Errorf("workbench endpoint preflight failed for %s: %s", versionURL, detail)
 	}
 
-	canonicalPath := filepath.Join(projectDir, "scripts", "demo-objects.sh")
-	data, err := os.ReadFile(canonicalPath) // #nosec G304 -- path is scoped to the selected project.
-	if err != nil {
-		return "", fmt.Errorf("read canonical demo-objects script: %w", err)
-	}
-	script, err := prepareDemoObjectsScript(data)
-	if err != nil {
-		return "", err
-	}
-	scriptPath, cleanupScript, err := materializeDemoObjectsScript(filepath.Join("scripts", "demo-objects.sh"), data, script)
-	if err != nil {
-		return "", err
-	}
-	defer cleanupScript()
-
-	command := exec.CommandContext(ctx, "bash", scriptPath) // #nosec G204 -- the tracked template script is the canonical operation.
+	command := exec.CommandContext(ctx, "bash", filepath.Join("scripts", "demo-objects.sh")) // #nosec G204 -- the tracked template script is the canonical operation.
 	command.Dir = projectDir
 	command.Env = append(os.Environ(), "SITECTL_DEMO_OBJECTS_URL="+createpkg.LocalDrupalBaseURL)
 	var stdout bytes.Buffer
@@ -431,50 +441,31 @@ func runDemoObjectsScript(ctx context.Context, projectDir string) (string, error
 	return stdout.String(), nil
 }
 
-func materializeDemoObjectsScript(path string, original []byte, prepared string) (string, func(), error) {
-	if prepared == string(original) {
-		return path, func() {}, nil
-	}
-
-	file, err := os.CreateTemp("", "sitectl-isle-demo-objects-*.sh")
-	if err != nil {
-		return "", nil, fmt.Errorf("create compatible demo-objects script: %w", err)
-	}
-	temporaryPath := file.Name()
-	cleanup := func() {
-		_ = os.Remove(temporaryPath) // Best-effort cleanup; the operating system also removes its temporary directory.
-	}
-	if _, err := file.WriteString(prepared); err != nil {
-		_ = file.Close()
-		cleanup()
-		return "", nil, fmt.Errorf("write compatible demo-objects script: %w", err)
-	}
-	if err := file.Close(); err != nil {
-		cleanup()
-		return "", nil, fmt.Errorf("close compatible demo-objects script: %w", err)
-	}
-
-	return temporaryPath, cleanup, nil
-}
-
-func prepareDemoObjectsScript(data []byte) (string, error) {
+func validateDemoObjectsScriptContract(data []byte) error {
 	script := string(data)
-	const managedURL = `URL="${SITECTL_DEMO_OBJECTS_URL:-$(site_url)}"`
-	if strings.Contains(script, managedURL) && strings.Contains(script, `container_url_for_url "${URL}"`) && strings.Contains(script, `container_network_for_url "${WORKBENCH_URL}"`) {
-		return script, nil
+	required := []struct {
+		label    string
+		fragment string
+	}{
+		{label: "SITECTL_DEMO_OBJECTS_URL override", fragment: `URL="${SITECTL_DEMO_OBJECTS_URL:-$(site_url)}"`},
+		{label: "container URL translation", fragment: `container_url_for_url "${URL}"`},
+		{label: "container network selection", fragment: `container_network_for_url "${WORKBENCH_URL}"`},
 	}
-
-	const profileSource = `source "$(dirname "${BASH_SOURCE[0]}")/profile.sh"`
-	const publicURL = `URL="${URI_SCHEME}://${DOMAIN}"`
-	const appendPublishedPort = `if [ "${URI_PORT}" != "80" ] && [ "${URI_PORT}" != "443" ]; then`
-	if !strings.Contains(script, profileSource) || !strings.Contains(script, publicURL) || !strings.Contains(script, appendPublishedPort) {
-		return "", fmt.Errorf("canonical demo-objects script has an unknown URL contract")
+	missing := make([]string, 0, len(required))
+	for _, requirement := range required {
+		if !strings.Contains(script, requirement.fragment) {
+			missing = append(missing, requirement.label)
+		}
 	}
-	script = strings.Replace(script, profileSource, `source "./scripts/profile.sh"`, 1)
-	script = strings.Replace(script, publicURL, `URL="${SITECTL_DEMO_OBJECTS_URL:-${URI_SCHEME}://${DOMAIN}}"`, 1)
-	script = strings.Replace(script, appendPublishedPort, `if [ -z "${SITECTL_DEMO_OBJECTS_URL:-}" ] && [ "${URI_PORT}" != "80" ] && [ "${URI_PORT}" != "443" ]; then`, 1)
-
-	return script, nil
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"scripts/demo-objects.sh uses a legacy runtime contract (missing %s); replace it from %s at %s or newer",
+		strings.Join(missing, ", "),
+		defaultTemplateRepo,
+		defaultTemplateBranch,
+	)
 }
 
 func demoObjectAssertTarget(fcrepoExpected, fileSystemURI string) (string, string) {
@@ -490,15 +481,11 @@ func demoObjectAssertTarget(fcrepoExpected, fileSystemURI string) (string, strin
 }
 
 func countContainerFiles(ctx context.Context, projectDir, service, target string) (int, error) {
-	out, err := runLocalProjectOutput(ctx, projectDir, "docker", "compose", "exec", "-T", service, "bash", "-lc", "find "+strconv.Quote(target)+" -type f 2>/dev/null | wc -l")
+	out, err := verifyRunLocalProjectOutput(ctx, projectDir, "docker", "compose", "exec", "-T", service, "find", target, "-type", "f", "-print0")
 	if err != nil {
 		return 0, err
 	}
-	count, err := strconv.Atoi(strings.TrimSpace(out))
-	if err != nil {
-		return 0, fmt.Errorf("parse file count %q: %w", strings.TrimSpace(out), err)
-	}
-	return count, nil
+	return bytes.Count([]byte(out), []byte{0}), nil
 }
 
 func verifyProjectFileContains(projectDir, relPath, expected, name string) sitevalidate.Result {

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -52,33 +53,7 @@ func TestBotMitigationForwardedHeaderProbeEnabledDetectsIngressTrustedIPs(t *tes
 	}
 }
 
-func TestPrepareDemoObjectsScriptUsesInternalRoute(t *testing.T) {
-	t.Parallel()
-
-	input := `#!/usr/bin/env bash
-set -eou pipefail
-source "$(dirname "${BASH_SOURCE[0]}")/profile.sh"
-URL="${URI_SCHEME}://${DOMAIN}"
-if [ "${URI_PORT}" != "80" ] && [ "${URI_PORT}" != "443" ]; then
-  URL="${URL}:${URI_PORT}"
-fi
-`
-	prepared, err := prepareDemoObjectsScript([]byte(input))
-	if err != nil {
-		t.Fatalf("prepareDemoObjectsScript() error = %v", err)
-	}
-	for _, want := range []string{
-		`source "./scripts/profile.sh"`,
-		`URL="${SITECTL_DEMO_OBJECTS_URL:-${URI_SCHEME}://${DOMAIN}}"`,
-		`if [ -z "${SITECTL_DEMO_OBJECTS_URL:-}" ]`,
-	} {
-		if !strings.Contains(prepared, want) {
-			t.Fatalf("expected prepared script to contain %q, got:\n%s", want, prepared)
-		}
-	}
-}
-
-func TestPrepareDemoObjectsScriptAcceptsManagedInternalRoute(t *testing.T) {
+func TestValidateDemoObjectsScriptContractAcceptsManagedInternalRoute(t *testing.T) {
 	t.Parallel()
 
 	input := `#!/usr/bin/env bash
@@ -87,56 +62,119 @@ URL="${SITECTL_DEMO_OBJECTS_URL:-$(site_url)}"
 WORKBENCH_URL="$(container_url_for_url "${URL}")"
 NETWORK="$(container_network_for_url "${WORKBENCH_URL}")"
 `
-	prepared, err := prepareDemoObjectsScript([]byte(input))
-	if err != nil {
-		t.Fatalf("prepareDemoObjectsScript() error = %v", err)
-	}
-	if prepared != input {
-		t.Fatalf("managed demo script was unexpectedly rewritten:\n%s", prepared)
+	if err := validateDemoObjectsScriptContract([]byte(input)); err != nil {
+		t.Fatalf("validateDemoObjectsScriptContract() error = %v", err)
 	}
 }
 
-func TestMaterializeDemoObjectsScriptUsesCanonicalFileWhenUnchanged(t *testing.T) {
+func TestValidateDemoObjectsScriptContractRejectsLegacyContractActionably(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "demo-objects.sh")
-	original := []byte("#!/usr/bin/env bash\nprintf 'canonical\\n'\n")
-	if err := os.WriteFile(path, original, 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
+	input := `#!/usr/bin/env bash
+set -eou pipefail
+URL="${URI_SCHEME}://${DOMAIN}"
+`
+	err := validateDemoObjectsScriptContract([]byte(input))
+	if err == nil {
+		t.Fatal("expected legacy contract failure")
 	}
-
-	gotPath, cleanup, err := materializeDemoObjectsScript(path, original, string(original))
-	if err != nil {
-		t.Fatalf("materializeDemoObjectsScript() error = %v", err)
-	}
-	defer cleanup()
-	if gotPath != path {
-		t.Fatalf("materializeDemoObjectsScript() path = %q, want %q", gotPath, path)
+	for _, want := range []string{"legacy runtime contract", "https://github.com/libops/isle", "v1.3.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
 	}
 }
 
-func TestMaterializeDemoObjectsScriptWritesPreparedCompatibilityFile(t *testing.T) {
+func TestRunDemoObjectsScriptRejectsLegacyContractBeforeRuntimeWork(t *testing.T) {
 	t.Parallel()
 
-	original := []byte("original\n")
-	prepared := "prepared\n"
-	gotPath, cleanup, err := materializeDemoObjectsScript("canonical.sh", original, prepared)
+	projectDir := t.TempDir()
+	scriptsDir := filepath.Join(projectDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(scripts) error = %v", err)
+	}
+	legacy := []byte("#!/usr/bin/env bash\nURL=\"${URI_SCHEME}://${DOMAIN}\"\n")
+	if err := os.WriteFile(filepath.Join(scriptsDir, "demo-objects.sh"), legacy, 0o644); err != nil {
+		t.Fatalf("WriteFile(demo-objects.sh) error = %v", err)
+	}
+	if _, err := runDemoObjectsScript(t.Context(), projectDir); err == nil || !strings.Contains(err.Error(), "legacy runtime contract") {
+		t.Fatalf("runDemoObjectsScript() error = %v, want an early legacy contract failure", err)
+	}
+}
+
+func TestVerifyNoFedoraManagedFilesUsesDirectDrushArgv(t *testing.T) {
+	oldRun := verifyRunLocalProjectOutput
+	t.Cleanup(func() {
+		verifyRunLocalProjectOutput = oldRun
+	})
+
+	var gotName string
+	var gotArgs []string
+	verifyRunLocalProjectOutput = func(ctx context.Context, projectDir, name string, args ...string) (string, error) {
+		gotName = name
+		gotArgs = append([]string{}, args...)
+		return "0\n", nil
+	}
+
+	result := verifyNoFedoraManagedFiles(context.Background(), t.TempDir())
+	if result.Status != sitevalidate.StatusOK {
+		t.Fatalf("verifyNoFedoraManagedFiles() = %#v", result)
+	}
+	wantArgs := []string{
+		"compose", "exec", "-T", "--workdir", "/var/www/drupal", "drupal",
+		"drush", "--root=/var/www/drupal", "sql:query", "--extra=--skip-column-names",
+		"SELECT COUNT(*) FROM file_managed WHERE uri LIKE 'fedora%';",
+	}
+	if gotName != "docker" || !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("command = %q %#v, want docker %#v", gotName, gotArgs, wantArgs)
+	}
+}
+
+func TestCountContainerFilesUsesDirectFindArgv(t *testing.T) {
+	oldRun := verifyRunLocalProjectOutput
+	t.Cleanup(func() {
+		verifyRunLocalProjectOutput = oldRun
+	})
+
+	var gotName string
+	var gotArgs []string
+	verifyRunLocalProjectOutput = func(ctx context.Context, projectDir, name string, args ...string) (string, error) {
+		gotName = name
+		gotArgs = append([]string{}, args...)
+		return "first\x00second\x00", nil
+	}
+
+	count, err := countContainerFiles(context.Background(), t.TempDir(), "drupal", "/var/www/drupal/private")
 	if err != nil {
-		t.Fatalf("materializeDemoObjectsScript() error = %v", err)
+		t.Fatalf("countContainerFiles() error = %v", err)
 	}
-	if gotPath == "canonical.sh" {
-		t.Fatal("materializeDemoObjectsScript() unexpectedly reused the canonical path")
+	if count != 2 {
+		t.Fatalf("countContainerFiles() = %d, want 2", count)
 	}
-	contents, err := os.ReadFile(gotPath)
+	wantArgs := []string{"compose", "exec", "-T", "drupal", "find", "/var/www/drupal/private", "-type", "f", "-print0"}
+	if gotName != "docker" || !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("command = %q %#v, want docker %#v", gotName, gotArgs, wantArgs)
+	}
+}
+
+func TestVerifyRuntimeDoesNotMaterializeCompatibilityPrograms(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("verify.go")
 	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
+		t.Fatalf("ReadFile(verify.go) error = %v", err)
 	}
-	if string(contents) != prepared {
-		t.Fatalf("materializeDemoObjectsScript() contents = %q, want %q", contents, prepared)
-	}
-	cleanup()
-	if _, err := os.Stat(gotPath); !os.IsNotExist(err) {
-		t.Fatalf("cleanup left compatibility script at %q: %v", gotPath, err)
+	source := string(data)
+	for _, forbidden := range []string{
+		"prepareDemoObjectsScript(",
+		"materializeDemoObjectsScript(",
+		"os.CreateTemp(",
+		`"bash", "-lc"`,
+		"| wc -l",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("verify runtime must invoke checked-in programs and direct argv instead of containing %q", forbidden)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 		Version:      fmt.Sprintf("%s (Built on %s from Git SHA %s)", version, date, commit),
 		Description:  "Islandora (ISLE) utilities and migration tools",
 		Author:       "libops",
-		TemplateRepo: "https://github.com/islandora-devops/isle-site-template",
+		TemplateRepo: "https://github.com/libops/isle",
 		Includes:     cmd.IncludedPlugins(),
 	})
 


### PR DESCRIPTION
Delegate lifecycle behavior to the versioned LibOps ISLE template, add a pre-down compatibility gate before customer outages, and invoke container tools with direct argv or checked-in programs. Hosted integration tracks the companion template branch until v1.3.0 is published.