### PR TITLE
[skip-release] Advance race-safe package publisher

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   goreleaser:
-    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@5f44a8c8d157bb7e5cf6d9e1c98847a604e87455 # main
+    uses: libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@6c580dd000630ed696249a1a9bbb0fc88efa30d0 # main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -68,7 +68,7 @@ jobs:
       project-path: isle-site-template
       local-plugin-path: sitectl-isle
       packages: sitectl sitectl-drupal
-      package-versions: sitectl=1.8.1 sitectl-drupal=1.3.0
+      package-versions: sitectl=1.8.2 sitectl-drupal=1.4.1
       allow-unversioned-packages: false
       expected-template-lock-revision: v1.0.0
       timeout-minutes: 120

--- a/.github/workflows/release-config.yaml
+++ b/.github/workflows/release-config.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Verify trusted package publisher workflow
         shell: bash
         env:
-          EXPECTED_WORKFLOW: "libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@5f44a8c8d157bb7e5cf6d9e1c98847a604e87455"
+          EXPECTED_WORKFLOW: "libops/.github/.github/workflows/sitectl-plugin-goreleaser.yaml@6c580dd000630ed696249a1a9bbb0fc88efa30d0"
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Pins the shared plugin release workflow to the merged race-safe package publisher. This is release-infrastructure maintenance only and must not create an application plugin release.